### PR TITLE
Fixes post-generation declarations when called via the getfuncargvalue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.1.3
+-----
+
+- circular dependency determination is fixed for the post-generation (olegpidsadnyi)
+
+
 1.1.2
 -----
 

--- a/pytest_factoryboy/__init__.py
+++ b/pytest_factoryboy/__init__.py
@@ -1,7 +1,7 @@
 """pytest-factoryboy public API."""
 from .fixture import register, LazyFixture
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 
 __all__ = [

--- a/tests/test_postgen_dependencies.py
+++ b/tests/test_postgen_dependencies.py
@@ -88,3 +88,8 @@ def test_depends_on_1(depends_on_1):
 def test_depends_on_2(depends_on_2):
     """Test that post-generation hooks are done and the value is 1."""
     assert depends_on_2.foo.value == 1
+
+
+def test_getfuncargvalue(request):
+    """Test post-generation declarations via the getfuncargvalue."""
+    assert request.getfuncargvalue('foo')


### PR DESCRIPTION
Doesn't fix circular dependencies for the pytest-bdd yet, but those situations have to be solved via the step hooks. I guess if we reset the factoryboy request "initialized" property on every step and call evaluate in the end of the every step it will solve it.
For now it should solve the basic problem when getfuncargvalue can't find the model fixture when computed instantly together with the post-generation declarations.