### PR TITLE
Replace deprecated addhooks call.

### DIFF
--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -58,4 +58,4 @@ def pytest_runtest_call(item):
 def pytest_addhooks(pluginmanager):
     """Register plugin hooks."""
     from pytest_factoryboy import hooks
-    pluginmanager.addhooks(hooks)
+    pluginmanager.add_hookspecs(hooks)


### PR DESCRIPTION
Breaks in pytest 2.8 due to a regression. See https://github.com/pytest-dev/pytest/issues/1034