### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ double underscore (similar to the convention used by factory_boy).
 
 .. code-block:: python
 
-    @pytest.mark.parametrized("author__name", ["Bill Gates"])
+    @pytest.mark.parametrize("author__name", ["Bill Gates"])
     def test_model_fixture(author):
         assert author.name == "Bill Gates"
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/24)
<!-- Reviewable:end -->
