### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ factory_boy_ integration with the pytest_ runner
 pytest-factoryboy makes it easy to combine ``factory`` approach to the test setup with the ``dependency`` injection,
 heart of the `pytest fixtures`_.
 
-.. _factory_boy: http://factoryboy.readthedocs.org
+.. _factory_boy: https://factoryboy.readthedocs.io
 .. _pytest: http://pytest.org
 .. _pytest fixtures: https://pytest.org/latest/fixture.html
 .. _overridden: http://pytest.org/latest/fixture.html#override-a-fixture-with-direct-test-parametrization


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/25)
<!-- Reviewable:end -->
