### PR TITLE
Remove post deps

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ These people have contributed to `pytest-factoryboy`, in alphabetical order:
 
 * `Anatoly Bubenkov <bubenkoff@gmail.com>`_
 * `Daniel Duong`
+* `Vasily Kuznetsov https://github.com/kvas-it`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.2.0
+-----
+
+- automatical resolution of the post-generation dependencies (olegpidsadnyi, kvas-it)
+
+
 1.1.6
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -296,7 +296,8 @@ This solves circular dependecy resolution for situations like:
 
 On the other hand deferring the evaluation of post-generation declarations evaluation makes their result unavailable during the generation
 of objects that are not in the circular dependecy, but they rely on the post-generation action.
-It is possible to declare such dependencies to be evaluated earlier, right before generating the requested object.
+
+pytest-factoryboy is trying to detect cycles and resolve post-generation dependencies automatically.
 
 
 .. code-block:: python
@@ -349,7 +350,6 @@ It is possible to declare such dependencies to be evaluated earlier, right befor
     register(
         BarFactory,
         'bar',
-        _postgen_dependencies=["foo__set1"],
     )
     """Forces 'set1' to be evaluated first."""
 
@@ -357,10 +357,6 @@ It is possible to declare such dependencies to be evaluated earlier, right befor
     def test_depends_on_set1(bar):
         """Test that post-generation hooks are done and the value is 2."""
         assert depends_on_1.foo.value == 1
-
-
-All post-generation/RelatedFactory attributes specified in the `_postgen_dependencies` list during factory registration
-are evaluated before the object generation.
 
 
 Hooks

--- a/pytest_factoryboy/__init__.py
+++ b/pytest_factoryboy/__init__.py
@@ -1,7 +1,7 @@
 """pytest-factoryboy public API."""
 from .fixture import register, LazyFixture
 
-__version__ = '1.1.6'
+__version__ = '1.2.0'
 
 
 __all__ = [

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -4,65 +4,98 @@ from collections import defaultdict
 import pytest
 
 
-class Request(object):
+class CycleDetected(Exception):
+    pass
 
+
+class Request(object):
     """PyTest FactoryBoy request."""
 
-    def __init__(self, request):
-        """Create pytest_factoryboy request.
-
-        :param request: pytest request.
-        """
-        self.request = request
+    def __init__(self):
+        """Create pytest_factoryboy request."""
         self.deferred = []
-        self.is_finalized = False
         self.results = defaultdict(dict)
         self.model_factories = {}
+        self.in_progress = set()
 
-    def defer(self, function):
+    def defer(self, functions):
         """Defer post-generation declaration execution until the end of the test setup.
 
-        :param function: Function to be deferred.
+        :param functions: Functions to be deferred.
         :note: Once already finalized all following defer calls will execute the function directly.
         """
-        self.deferred.append(function)
-        if self.is_finalized:
-            self.execute(function)
+        self.deferred.append(functions)
 
-    def execute(self, function):
+    def get_deps(self, request, fixture, deps=None):
+        request = request.getfuncargvalue('request')
+
+        if deps is None:
+            deps = set([fixture])
+        if fixture == 'request':
+            return deps
+
+        for fixturedef in request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent.nodeid):
+            for argname in fixturedef.argnames:
+                if argname not in deps:
+                    deps.add(argname)
+                    deps.update(self.get_deps(request, argname, deps))
+        return deps
+
+    def get_current_deps(self, request):
+        deps = set()
+        while hasattr(request, '_parent_request'):
+            if request.fixturename and request.fixturename not in request._fixturedefs:
+                deps.add(request.fixturename)
+            request = request._parent_request
+        return deps
+
+    def execute(self, request, function, deferred):
         """"Execute deferred function and store the result."""
-        model, attr = function.__name__.split("__", 1)
-        self.results[model][attr] = function(self.request)
+        if function in self.in_progress:
+            raise CycleDetected()
+        fixture = function.__name__
+        model, attr = fixture.split("__", 1)
+        if function._is_related:
+            deps = self.get_deps(request, fixture)
+            if deps.intersection(self.get_current_deps(request)):
+                raise CycleDetected()
         self.model_factories[model] = function._factory
-        self.deferred.remove(function)
 
-    def after_postgeneration(self):
+        self.in_progress.add(function)
+        self.results[model][attr] = function(request)
+        deferred.remove(function)
+        self.in_progress.remove(function)
+
+    def after_postgeneration(self, request):
         """Call _after_postgeneration hooks."""
         for model in list(self.results.keys()):
             results = self.results.pop(model)
-            obj = self.request.getfuncargvalue(model)
+            obj = request.getfuncargvalue(model)
             factory = self.model_factories[model]
             factory._after_postgeneration(obj=obj, create=True, results=results)
 
-    def evaluate(self, names=None):
+    def evaluate(self, request):
         """Finalize, run deferred post-generation actions, etc."""
-        if names:
-            functions = dict((function.__name__, function) for function in self.deferred if function.__name__ in names)
-            deferred = [functions[name] for name in names if functions.get(name)]
-        else:
-            deferred = list(self.deferred)
-
-        for function in deferred:
-            self.execute(function)
+        while self.deferred:
+            try:
+                deferred = self.deferred[-1]
+                for function in list(deferred):
+                    self.execute(request, function, deferred)
+                if not deferred:
+                    self.deferred.remove(deferred)
+            except IndexError:
+                return
+            except CycleDetected:
+                return
 
         if not self.deferred:
-            self.after_postgeneration()
+            self.after_postgeneration(request)
 
 
 @pytest.fixture
-def factoryboy_request(request):
+def factoryboy_request():
     """PyTest FactoryBoy request fixture."""
-    return Request(request)
+    return Request()
 
 
 @pytest.mark.tryfirst
@@ -74,8 +107,8 @@ def pytest_runtest_call(item):
         # pytest-pep8 plugin passes Pep8Item here during tests.
         return
     factoryboy_request = request.getfuncargvalue("factoryboy_request")
-    factoryboy_request.evaluate()
-    factoryboy_request.is_finalized = True
+    factoryboy_request.evaluate(request)
+    assert not factoryboy_request.deferred
     request.config.hook.pytest_factoryboy_done(request=request)
 
 
@@ -85,3 +118,12 @@ def pytest_addhooks(pluginmanager):
     # addhooks is for older py.test and deprecated; replaced by add_hookspecs
     add_hookspecs = getattr(pluginmanager, 'add_hookspecs', pluginmanager.addhooks)
     add_hookspecs(hooks)
+
+
+def pytest_generate_tests(metafunc):
+    related = []
+    for arg2fixturedef in metafunc._arg2fixturedefs.values():
+        fixturedef = arg2fixturedef[-1]
+        related.extend(getattr(fixturedef.func, "_factoryboy_related", []))
+
+    metafunc.funcargnames.extend(related)

--- a/tests/test_circular.py
+++ b/tests/test_circular.py
@@ -51,5 +51,5 @@ register(AuthorFactory)
 register(BookFactory)
 
 
-def test_circular(author):
+def test_circular(author, factoryboy_request, request):
     assert author.books


### PR DESCRIPTION
It seems to be possible to detect cyclic dependencies by traversing pytest fixturedefs.
This way if RelatedFactory declarations would be executed before post_generation declarations with some sort of heuristics it might work automatically without configuring post generation dependencies. Which is a hard problem as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/26)
<!-- Reviewable:end -->
