### PR TITLE
replace request._fixturedefs by request._fixture_defs, solve issue #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 sudo: false
 language: python
+# enable Python 3.5 on travis until it will be pre-installed
+python: 3.5
 env:
   matrix:
-  - TESTENV=py26
-  - TESTENV=py27
-  - TESTENV=py34
+  - TESTENV=py27-pytest2
+  - TESTENV=py34-pytest2
+  - TESTENV=py35-pytest2
+  - TESTENV=py27-pytest3
+  - TESTENV=py34-pytest3
+  - TESTENV=py35-pytest3
 install:
 - pip install tox
 script: tox -e $TESTENV

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -197,7 +197,10 @@ def model_fixture(request, factory_name):
     # Create model fixture instance
     instance = Factory(**data)
     request._fixturedef.cached_result = (instance, None, None)
-    request._fixture_defs[request.fixturename] = request._fixturedef
+    if hasattr(request, '_fixture_defs'):
+        request._fixture_defs[request.fixturename] = request._fixturedef
+    else:
+        request._fixturedefs[request.fixturename] = request._fixturedef
 
     # Defer post-generation declarations
     related = []

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -197,7 +197,7 @@ def model_fixture(request, factory_name):
     # Create model fixture instance
     instance = Factory(**data)
     request._fixturedef.cached_result = (instance, None, None)
-    request._fixturedefs[request.fixturename] = request._fixturedef
+    request._fixture_defs[request.fixturename] = request._fixturedef
 
     # Defer post-generation declarations
     related = []

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -43,8 +43,12 @@ class Request(object):
 
     def get_current_deps(self, request):
         deps = set()
+        if hasattr(request, '_fixture_defs'):
+            fixture_defs = request._fixture_defs
+        else:
+            fixture_defs = request._fixturedefs
         while hasattr(request, '_parent_request'):
-            if request.fixturename and request.fixturename not in request._fixture_defs:
+            if request.fixturename and request.fixturename not in fixture_defs:
                 deps.add(request.fixturename)
             request = request._parent_request
         return deps

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -44,7 +44,7 @@ class Request(object):
     def get_current_deps(self, request):
         deps = set()
         while hasattr(request, '_parent_request'):
-            if request.fixturename and request.fixturename not in request._fixturedefs:
+            if request.fixturename and request.fixturename not in request._fixture_defs:
                 deps.add(request.fixturename)
             request = request._parent_request
         return deps

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "Topic :: Utilities",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
-    ] + [("Programming Language :: Python :: %s" % x) for x in "2.6 2.7 3.0 3.1 3.2 3.3 3.4".split()],
+    ] + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.0 3.1 3.2 3.3 3.4 3.5".split()],
     install_requires=[
         "inflection",
         "factory_boy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py26,py27,py34
+envlist = py{26,27,34,35}-pytest{2,3}
 
 [testenv]
 commands = py.test --junitxml={envlogdir}/junit-{envname}.xml pytest_factoryboy tests
-deps = -r{toxinidir}/requirements-testing.txt
+deps =
+    -r{toxinidir}/requirements-testing.txt
+    pytest2: pytest < 3
+    pytest3: pytest >= 3
 
 [pytest]
 addopts = -vv -l --pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py{26,27,34,35}-pytest{2,3}
+envlist = py{27,34,35}-pytest{2,3}
+
 
 [testenv]
 commands = py.test --junitxml={envlogdir}/junit-{envname}.xml pytest_factoryboy tests
-deps =
-    -r{toxinidir}/requirements-testing.txt
-    pytest2: pytest < 3
-    pytest3: pytest >= 3
+deps = -r{toxinidir}/requirements-testing.txt
+  pytest2: pytest<3.0
+  pytest3: pytest>3.0
 
 [pytest]
 addopts = -vv -l --pep8


### PR DESCRIPTION
SubRequest objects do not have any attribute '_fixturedefs' but an attribute '_fixture_defs' (see https://github.com/pytest-dev/pytest/blob/master/_pytest/fixtures.py#L588).
Pull request for this issue: https://github.com/pytest-dev/pytest-factoryboy/issues/29
(Solve a regression introduced in this commit : d5a37f5)