### PR TITLE
Correct factory in the last LazyFixture example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,7 +275,7 @@ LazyFixture constructor accepts either existing fixture name or callable with de
 
 
     # Can also be used in the partial specialization during the registration.
-    register(AuthorFactory, "another_book", author=LazyFixture("another_author"))
+    register(BookFactory, "another_book", author=LazyFixture("another_author"))
 
 
 Post-generation dependencies


### PR DESCRIPTION
I think AuthorFactory is wrong here, found this slightly confusing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/35)
<!-- Reviewable:end -->
