### PR TITLE
tox.ini: use {posargs} in pytest command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{27,34,35}-pytest{2,3}
 
 
 [testenv]
-commands = py.test --junitxml={envlogdir}/junit-{envname}.xml pytest_factoryboy tests
+commands = py.test --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
 deps = -r{toxinidir}/requirements-testing.txt
   pytest2: pytest<3.0
   pytest3: pytest>3.0


### PR DESCRIPTION
This allows to pass in arguments for pytest, e.g. `-k` or the test
path(s).

This also removes the pytest_factoryboy dir, since it does not contain
any tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/45)
<!-- Reviewable:end -->
