### PR TITLE
A failing test for registering "foo_factory", coming from FooFactory

### DIFF
--- a/tests/test_register_class.py
+++ b/tests/test_register_class.py
@@ -1,0 +1,19 @@
+import factory
+from pytest_factoryboy import register
+
+
+class EmptyModel(object):
+    pass
+
+
+class FooFactory(factory.Factory):
+    class Meta:
+        model = EmptyModel
+
+
+register(FooFactory, "foo_factory")
+
+
+def test_factory_with_attributes(foo_factory):
+    """Test that foo_factory can be used / throws a proper error."""
+    pass


### PR DESCRIPTION
This causes a weird "fixture 'foo_factory' not found" error, which seems
to be caused by `FooFactory` setting/conflicting with `foo_factory`?!

    collected 2 items

    tests/test_register_class.py PASSED
    tests/test_register_class.py::test_factory_with_attributes ERROR

    - generated xml file: …/pytest-factoryboy/.tox/py36-pytest3/log/junit-py36-pytest3.xml --
    ================================================ ERRORS ================================================
    ____________________________ ERROR at setup of test_factory_with_attributes ____________________________
    file …/pytest-factoryboy/tests/test_register_class.py, line 17
      def test_factory_with_attributes(foo_factory):
    file <string>, line 2: source code not available
    E       fixture 'foo_factory' not found
    >       available fixtures: cache, capfd, caplog, capsys, capturelog, cov, doctest_namespace, factoryboy_request, foo_factory, monkeypatch, pytestconfig, record_xml_property, recwarn, tmpdir, tmpdir_factory
    >       use 'pytest --fixtures [testpath]' for help on them.

    <string>:2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/46)
<!-- Reviewable:end -->
