### PR TITLE
Failing test for using a `attributes` field on the factory

### DIFF
--- a/tests/test_attributes_field.py
+++ b/tests/test_attributes_field.py
@@ -1,0 +1,21 @@
+from pytest_factoryboy import register
+import factory
+
+
+class EmptyModel(object):
+    pass
+
+
+class AttributesFactory(factory.Factory):
+    class Meta:
+        model = EmptyModel
+
+    attributes = None
+
+
+register(AttributesFactory, "with_attributes")
+
+
+def test_factory_with_attributes(with_attributes):
+    """Test that a factory can have a `attributes` field."""
+    pass


### PR DESCRIPTION
```
cls = <class 'pytest_factoryboy.fixture.model_fixture.<locals>.Factory'>, args = (), kwargs = {'create': True, 'extra': {'attributes': None}}

    @classmethod
    def attributes(cls, *args, **kwargs):
        return dict(
            (key, value)
>           for key, value in super(Factory, cls).attributes(*args, **kwargs).items()
            if key in data
        )
E       TypeError: 'NoneType' object is not callable

Factory    = <class 'pytest_factoryboy.fixture.model_fixture.<locals>.Factory'>
__class__  = <class 'pytest_factoryboy.fixture.model_fixture.<locals>.Factory'>
args       = ()
cls        = <class 'pytest_factoryboy.fixture.model_fixture.<locals>.Factory'>
data       = {'attributes': None}
kwargs     = {'create': True, 'extra': {'attributes': None}}

.tox/py36-pytest3/lib/python3.6/site-packages/pytest_factoryboy/fixture.py:184: TypeError
```

Might be fixable by adopting the recent/unreleased refactors on factory_boy master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/48)
<!-- Reviewable:end -->
