### PR TITLE
Fix deprecation warning for pytest 3.0 - use of getfuncargvalue is deprecated, use getfixturevalue

### DIFF
--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -2,7 +2,7 @@
 
 
 def get_fixture_value(request, *args):
-    """Compatibility check for pytest2 FixtureRequest.getfunctargvalue method."""
+    """Compatibility check for pytest2 FixtureRequest.getfuncargvalue method."""
     try:
         return request.getfixturevalue(*args)
     except AttributeError:

--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -1,0 +1,9 @@
+"""pytest-factoryboy compatibility."""
+
+
+def get_fixture_value(request, *args):
+    """Compatibility check for pytest2 FixtureRequest.getfunctargvalue method."""
+    try:
+        return request.getfixturevalue(*args)
+    except AttributeError:
+        return request.getfuncargvalue(*args)

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -6,7 +6,7 @@ import inspect
 import factory
 import inflection
 import pytest
-
+from .compat import get_fixture_value
 
 SEPARATOR = "__"
 
@@ -163,17 +163,17 @@ def evaluate(request, value):
 
 def model_fixture(request, factory_name):
     """Model fixture implementation."""
-    factoryboy_request = request.getfixturevalue("factoryboy_request")
+    factoryboy_request = get_fixture_value(request, "factoryboy_request")
 
     # Try to evaluate as much post-generation dependencies as possible
     factoryboy_request.evaluate(request)
 
-    factory_class = request.getfixturevalue(factory_name)
+    factory_class = get_fixture_value(request, factory_name)
     prefix = "".join((request.fixturename, SEPARATOR))
     data = {}
     for argname in request._fixturedef.argnames:
         if argname.startswith(prefix) and argname[len(prefix):] not in factory_class._meta.postgen_declarations:
-            data[argname[len(prefix):]] = evaluate(request, request.getfixturevalue(argname))
+            data[argname[len(prefix):]] = evaluate(request, get_fixture_value(request, argname))
 
     class Factory(factory_class):
 
@@ -232,8 +232,8 @@ def make_deferred_related(factory, fixture, attr):
     name = SEPARATOR.join((fixture, attr))
 
     def deferred(request):
-        request.getfixturevalue(name)
-        # return request.getfixturevalue(name)
+        get_fixture_value(request, name)
+        # return get_fixture_value(request, name)
     deferred.__name__ = name
     deferred._factory = factory
     deferred._fixture = fixture
@@ -255,7 +255,7 @@ def make_deferred_postgen(factory, fixture, instance, attr, declaration, context
     name = SEPARATOR.join((fixture, attr))
 
     def deferred(request):
-        context.value = evaluate(request, request.getfixturevalue(name))
+        context.value = evaluate(request, get_fixture_value(request, name))
         context.extra = dict((key, evaluate(request, value)) for key, value in context.extra.items())
         declaration.call(instance, True, context)
         # return context.value
@@ -279,7 +279,7 @@ def attr_fixture(request, value):
 def subfactory_fixture(request, factory_class):
     """SubFactory/RelatedFactory fixture implementation."""
     fixture = inflection.underscore(factory_class._meta.model.__name__)
-    return request.getfixturevalue(fixture)
+    return get_fixture_value(request, fixture)
 
 
 def get_caller_module(depth=2):
@@ -314,7 +314,7 @@ class LazyFixture(object):
         :return: evaluated fixture.
         """
         if callable(self.fixture):
-            kwargs = dict((arg, request.getfixturevalue(arg)) for arg in self.args)
+            kwargs = dict((arg, get_fixture_value(request, arg)) for arg in self.args)
             return self.fixture(**kwargs)
         else:
-            return request.getfixturevalue(self.fixture)
+            return get_fixture_value(request, self.fixture)

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -27,7 +27,7 @@ class Request(object):
         self.deferred.append(functions)
 
     def get_deps(self, request, fixture, deps=None):
-        request = request.getfuncargvalue('request')
+        request = request.getfixturevalue('request')
 
         if deps is None:
             deps = set([fixture])
@@ -74,7 +74,7 @@ class Request(object):
         """Call _after_postgeneration hooks."""
         for model in list(self.results.keys()):
             results = self.results.pop(model)
-            obj = request.getfuncargvalue(model)
+            obj = request.getfixturevalue(model)
             factory = self.model_factories[model]
             factory._after_postgeneration(obj=obj, create=True, results=results)
 
@@ -108,7 +108,7 @@ def pytest_runtest_call(item):
     except AttributeError:
         # pytest-pep8 plugin passes Pep8Item here during tests.
         return
-    factoryboy_request = request.getfuncargvalue("factoryboy_request")
+    factoryboy_request = request.getfixturevalue("factoryboy_request")
     factoryboy_request.evaluate(request)
     assert not factoryboy_request.deferred
     request.config.hook.pytest_factoryboy_done(request=request)

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 import pytest
+from .compat import get_fixture_value
 
 
 class CycleDetected(Exception):
@@ -27,7 +28,7 @@ class Request(object):
         self.deferred.append(functions)
 
     def get_deps(self, request, fixture, deps=None):
-        request = request.getfixturevalue('request')
+        request = get_fixture_value(request, 'request')
 
         if deps is None:
             deps = set([fixture])
@@ -74,7 +75,7 @@ class Request(object):
         """Call _after_postgeneration hooks."""
         for model in list(self.results.keys()):
             results = self.results.pop(model)
-            obj = request.getfixturevalue(model)
+            obj = get_fixture_value(request, model)
             factory = self.model_factories[model]
             factory._after_postgeneration(obj=obj, create=True, results=results)
 
@@ -108,7 +109,7 @@ def pytest_runtest_call(item):
     except AttributeError:
         # pytest-pep8 plugin passes Pep8Item here during tests.
         return
-    factoryboy_request = request.getfixturevalue("factoryboy_request")
+    factoryboy_request = get_fixture_value(request, "factoryboy_request")
     factoryboy_request.evaluate(request)
     assert not factoryboy_request.deferred
     request.config.hook.pytest_factoryboy_done(request=request)

--- a/tests/test_postgen_dependencies.py
+++ b/tests/test_postgen_dependencies.py
@@ -4,6 +4,7 @@ import factory
 import pytest
 
 from pytest_factoryboy import register
+from pytest_factoryboy.compat import get_fixture_value
 
 
 class Foo(object):
@@ -75,7 +76,7 @@ def test_depends_on(bar):
 
 def test_getfixturevalue(request, factoryboy_request):
     """Test post-generation declarations via the getfixturevalue."""
-    foo = request.getfixturevalue('foo')
+    foo = get_fixture_value(request, 'foo')
     assert not factoryboy_request.deferred
     assert foo.value == 1
 

--- a/tests/test_postgen_dependencies.py
+++ b/tests/test_postgen_dependencies.py
@@ -73,9 +73,9 @@ def test_depends_on(bar):
     assert bar.foo.value == 1
 
 
-def test_getfuncargvalue(request, factoryboy_request):
-    """Test post-generation declarations via the getfuncargvalue."""
-    foo = request.getfuncargvalue('foo')
+def test_getfixturevalue(request, factoryboy_request):
+    """Test post-generation declarations via the getfixturevalue."""
+    foo = request.getfixturevalue('foo')
     assert not factoryboy_request.deferred
     assert foo.value == 1
 


### PR DESCRIPTION
Replace getfuncargvalue with getfixturevalue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/49)
<!-- Reviewable:end -->
