### PR TITLE
Monkeypatch FactoryOptions for backwards compatibility

### DIFF
--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -193,7 +193,6 @@ def evaluate(request, value):
 
 def model_fixture(request, factory_name):
     """Model fixture implementation."""
-    monkeypatch_factory_class(factory_class)
 
     factoryboy_request = request.getfuncargvalue("factoryboy_request")
 
@@ -201,6 +200,8 @@ def model_fixture(request, factory_name):
     factoryboy_request.evaluate(request)
 
     factory_class = request.getfuncargvalue(factory_name)
+    monkeypatch_factory_class(factory_class)
+
     prefix = "".join((request.fixturename, SEPARATOR))
     data = {}
     for argname in request._fixturedef.argnames:

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -24,13 +24,25 @@ def monkeypatch_factory_class(factory_class):
     to post_declarations, and uses builder.DeclarationSet which encapsulates
     the declarations
 
-    Patch the instance to work using 'postgen_declarations' parameter as well
+    Patch the instance to work using the old 'postgen_declarations' parameter
 
     :param factory_class: Factory class to patch
 
     """
     if hasattr(factory_class._meta, "post_declarations"):
-        factory_class._meta.postgen_declarations = factory_class._meta.post_declarations.declarations
+        # Change the instance's class to a patched one with an additional
+        # 'postgen_declarations' property
+        class_name = 'Patched' + factory_class._meta.__class__.__name__
+        patched_class = type(
+            class_name, (factory_class._meta.__class__,),
+            {
+                "postgen_declarations": property(
+                    lambda self: self.post_declarations.as_dict()
+                )
+            }
+        )
+
+        factory_class._meta.__class__ = patched_class
 
 
 def make_fixture(name, module, func, args=None, related=None, **kwargs):


### PR DESCRIPTION
Fixes #47 

factory_boy 2.9.0+ renames the 'postgen_declarations' parameter in FactoryOptions to 'post_declarations', and uses a DeclarationSet instead of a dict to handle the declarations.

This pull request monkey patches the newer FactoryOptions instances to include a 'postgen_declarations' property, which should behave similarly enough to the attribute in the older factory_boy versions.

pytest_factory's own unit tests don't pass with the branch as-is, but exposing the 'postgen_declarations' allowed the test suite for my Django web application to work again. factory_boy has gone through a lot of refactoring, so I doubt a complete fix would be nearly as simple.

The solution still feels quite hacky to me, so I'm up for a better solution if one is created. One option is dropping support for older factory_boy versions, though that would involve fixing the library to work with the newer factory_boy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/54)
<!-- Reviewable:end -->
