### PR TITLE
Fix warning `use of getfuncargvalue is deprecated, use getfixturevalue`

### DIFF
--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -70,7 +70,7 @@ class Request(object):
         """Call _after_postgeneration hooks."""
         for model in list(self.results.keys()):
             results = self.results.pop(model)
-            obj = request.getfuncargvalue(model)
+            obj = request.getfixturevalue(model)
             factory = self.model_factories[model]
             factory._after_postgeneration(obj, create=True, results=results)
 
@@ -104,7 +104,7 @@ def pytest_runtest_call(item):
     except AttributeError:
         # pytest-pep8 plugin passes Pep8Item here during tests.
         return
-    factoryboy_request = request.getfuncargvalue("factoryboy_request")
+    factoryboy_request = request.getfixturevalue("factoryboy_request")
     factoryboy_request.evaluate(request)
     assert not factoryboy_request.deferred
     request.config.hook.pytest_factoryboy_done(request=request)

--- a/tests/test_postgen_dependencies.py
+++ b/tests/test_postgen_dependencies.py
@@ -73,9 +73,9 @@ def test_depends_on(bar):
     assert bar.foo.value == 1
 
 
-def test_getfuncargvalue(request, factoryboy_request):
-    """Test post-generation declarations via the getfuncargvalue."""
-    foo = request.getfuncargvalue('foo')
+def test_getfixturevalue(request, factoryboy_request):
+    """Test post-generation declarations via the getfixturevalue."""
+    foo = request.getfixturevalue('foo')
     assert not factoryboy_request.deferred
     assert foo.value == 1
 


### PR DESCRIPTION
Fixes #68

getfixturevalue already exists since pytest version [3.0.0](https://docs.pytest.org/en/latest/changelog.html#id329)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/62)
<!-- Reviewable:end -->
