### PR TITLE
Use inspect.signature() to avoid deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "inflection",
         "factory_boy>=2.10.0",
         "pytest>=3.3.2",
+        'funcsigs;python_version<"3.0"',
     ],
     # the following makes a plugin available to py.test
     entry_points={


### PR DESCRIPTION
This avoids deprecation warning as inspect.getargspec() is deprecated in Python 3.5+

See https://github.com/pytest-dev/pytest-bdd/pull/164 for a similar fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/70)
<!-- Reviewable:end -->
