### PR TITLE
[WIP] Register model with all strategies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@
 develop: .env
 	.env/bin/pip install -e . -r requirements-testing.txt tox
 
-# clean the development envrironment
+# clean the development environment
 clean:
 	-rm -rf .env

--- a/pytest_factoryboy/__init__.py
+++ b/pytest_factoryboy/__init__.py
@@ -1,10 +1,11 @@
 """pytest-factoryboy public API."""
-from .fixture import register, LazyFixture
+from .fixture import register, register_strategies, LazyFixture
 
 __version__ = '2.0.2'
 
 
 __all__ = [
     register.__name__,
+    register_strategies.__name__,
     LazyFixture.__name__,
 ]

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -68,7 +68,9 @@ def register_strategies(factory_class, _name=None, strategies=None, **kwargs):
         for strategy in strategies:
             if strategy not in STRATEGIES:
                 raise AttributeError(
-                    f"{strategy} is not a valid strategy. Strategies available are: {STRATEGIES}"
+                    "{} is not a valid strategy. Strategies available are: {}".format(
+                        strategy, STRATEGIES
+                    )
                 )
     else:
         strategies = STRATEGIES
@@ -196,7 +198,7 @@ def get_factory_name(factory_class):
 
 def get_strategy_name(obj, strategy):
     strategy_str = "_" + strategy if strategy != "create" else ""
-    return f"{obj}{strategy_str}"
+    return obj + strategy_str
 
 
 def get_deps(factory_class, parent_factory_class=None, model_name=None):
@@ -391,7 +393,7 @@ def get_strategy_factory_class(factory_class, strategy):
         strategy_factory_class = factory_class
     else:
         strategy_factory_class = type(
-            f"{factory_class.__name__}{strategy.title()}",
+            (factory_class.__name__ + strategy.title()),
             factory_class.__bases__,
             dict(factory_class.__dict__),
         )

--- a/tests/test_factory_fixtures.py
+++ b/tests/test_factory_fixtures.py
@@ -199,19 +199,72 @@ def test_lazy_fixture_post_generation(author):
     assert author.user.password == "asdasd"
 
 
-register_strategies(BookFactory)
-register_strategies(EditionFactory)
 register_strategies(AuthorFactory)
 
 
+def test_register_strategies_factory(
+    author_factory, author_build_factory, author_stub_factory
+):
+    """Test register_strategies model factory fixture."""
+
+    assert author_factory.__name__ == "AuthorFactory"
+    assert author_build_factory.__name__ == "AuthorBuildFactory"
+    assert author_stub_factory.__name__ == "AuthorStubFactory"
+
+    assert author_factory._meta.strategy == "create"
+    assert author_build_factory._meta.strategy == "build"
+    assert author_stub_factory._meta.strategy == "stub"
+
+    assert (
+        len(
+            set((id(author_factory), id(author_build_factory), id(author_stub_factory)))
+        )
+        == 3
+    )
+
+
+register_strategies(BookFactory)
+register_strategies(EditionFactory)
+
+
+def test_register_strategies_relatedfactory(
+    book,
+    edition__book,
+    book_build,
+    edition_build__book,
+    book_stub,
+    edition_stub__book,
+):
+    """Test register_strategies RelatedFactory fixture."""
+
+    assert id(book) == id(edition__book)
+    assert id(book_build) == id(edition_build__book)
+    assert id(book_stub) == id(edition_stub__book)
+
+
+def test_register_strategies_subfactory(
+    book__author,
+    author,
+    book_build__author,
+    author_build,
+    book_stub__author,
+    author_stub,
+):
+    """Test register_strategies SubFactory fixture."""
+    assert id(book__author) == id(author)
+    assert id(book_build__author) == id(author_build)
+    assert id(book_stub__author) == id(author_stub)
+
+
 def test_register_strategies_models(book, book_build, book_stub):
-    """Test strategies models fixture."""
+    """Test register_strategies model fixture."""
+
     objs = (book, book_build, book_stub)
+
     assert all(obj.name == "Alice in Wonderland" for obj in objs)
     assert all(obj.price == 3.99 for obj in objs)
     assert all(obj.author.name == "Charles Dickens" for obj in objs)
     assert all(obj.author.user is None for obj in objs)
-    import ipdb; ipdb.set_trace(context=8)
     # Issue with related factory for build and stub fixtures
     # assert all(obj.editions[0].year == 1999 for obj in objs)
     # assert all(obj.editions[0].book == obj for obj in objs)
@@ -231,7 +284,7 @@ def test_strategies_attr(
     author_stub__name,
     edition_stub__year,
 ):
-    """Test strategies attributes fixtures.
+    """Test register_strategies attributes fixtures.
 
     :note: Most of the attributes are lazy definitions. Use attribute fixtures in
            order to override the initial values.

--- a/tests/test_factory_fixtures.py
+++ b/tests/test_factory_fixtures.py
@@ -228,12 +228,7 @@ register_strategies(EditionFactory)
 
 
 def test_register_strategies_relatedfactory(
-    book,
-    edition__book,
-    book_build,
-    edition_build__book,
-    book_stub,
-    edition_stub__book,
+    book, edition__book, book_build, edition_build__book, book_stub, edition_stub__book
 ):
     """Test register_strategies RelatedFactory fixture."""
 
@@ -258,16 +253,19 @@ def test_register_strategies_subfactory(
 
 def test_register_strategies_models(book, book_build, book_stub):
     """Test register_strategies model fixture."""
-
     objs = (book, book_build, book_stub)
 
     assert all(obj.name == "Alice in Wonderland" for obj in objs)
     assert all(obj.price == 3.99 for obj in objs)
     assert all(obj.author.name == "Charles Dickens" for obj in objs)
     assert all(obj.author.user is None for obj in objs)
-    # Issue with related factory for build and stub fixtures
-    # assert all(obj.editions[0].year == 1999 for obj in objs)
-    # assert all(obj.editions[0].book == obj for obj in objs)
+    
+    # Issue with related factory for build fixture
+    assert book.editions[0].year == book_build.editions[0].year == 1999
+    assert book.editions[0].book == book_build.editions[0].year == 1999
+    with pytest.raises(AttributeError) as excinfo:
+        book_stub.editions
+    excinfo.match(r"'StubObject' object has no attribute 'editions'")
 
 
 def test_strategies_attr(

--- a/tests/test_factory_fixtures.py
+++ b/tests/test_factory_fixtures.py
@@ -211,7 +211,7 @@ def test_register_strategies_models(book, book_build, book_stub):
     assert all(obj.price == 3.99 for obj in objs)
     assert all(obj.author.name == "Charles Dickens" for obj in objs)
     assert all(obj.author.user is None for obj in objs)
-
+    import ipdb; ipdb.set_trace(context=8)
     # Issue with related factory for build and stub fixtures
     # assert all(obj.editions[0].year == 1999 for obj in objs)
     # assert all(obj.editions[0].book == obj for obj in objs)


### PR DESCRIPTION
Add register_strategies function, which allows create all the different fixtures possible from a single model with the specified strategies(all strategies are used by default).

At the moment,  got a problem with SubFactory and RelatedFactory for build and stub strategies.
All SubFactory/RelatedFactory fixtures are created but when build/stub fixtures is called, RelatedFactory doesn't  exist and the SubFactory fixture used is a 'create' fixture and not a 'build'/'stub' fixture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/75)
<!-- Reviewable:end -->
