### PR TITLE
docs: clarify name convention of model fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ class name.
 Model Fixture
 -------------
 
-Model fixture implements an instance of a model created by the factory. Name convention is lowercase-underscore
+Model fixture implements an instance of a model created by the factory. Name convention is model's lowercase-underscore
 class name.
 
 


### PR DESCRIPTION
Docs regarding model's fixture name convention are phrased in the way that would suggest that the name is constructed by lowercasing and underscoring class name of the factory, not this factory's model class name. This pull request aims to fix that.