### PR TITLE
Drop support for old Python and pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 dist: xenial
 python:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,5 +9,6 @@ These people have contributed to `pytest-factoryboy`, in alphabetical order:
 * `Anatoly Bubenkov <bubenkoff@gmail.com>`_
 * `Daniel Duong <https://github.com/dduong42>`_
 * `Daniel Hahler <https://github.com/blueyed>`_
+* `Hugo van Kemenade <https://github.com/hugovk>`_
 * `p13773 <https://github.com/p13773>`_
 * `Vasily Kuznetsov <https://github.com/kvas-it>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Drop support for Python 3.4.
+- Drop support for pytest < 4.3.
+
+
 2.0.3
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     author_email="oleg.pidsadnyi@gmail.com",
     url="https://github.com/pytest-dev/pytest-factoryboy",
     version=VERSION,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         "Development Status :: 6 - Mature",
         "Intended Audience :: Developers",
@@ -38,7 +39,7 @@ setup(
         "Topic :: Utilities",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
-    ] + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.4 3.5 3.6 3.7".split()],
+    ] + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.5 3.6 3.7".split()],
     install_requires=[
         "inflection",
         "factory_boy>=2.10.0",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         "inflection",
         "factory_boy>=2.10.0",
-        "pytest>=3.3.2",
+        "pytest>=4.3",
         'funcsigs;python_version<"3.0"',
     ],
     # the following makes a plugin available to py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,18 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py27-pytest4,
-          py37-pytest{4,latest},
+envlist = py27-pytest{43,44,45,46},
+          py37-pytest{43,44,45,46,5,latest},
           py{35,36}-pytestlatest
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
 deps =
     pytestlatest: pytest
-    pytest4: pytest~=4.6.0
+    pytest5: pytest~=5.0.0
+    pytest46: pytest~=4.6.0
+    pytest45: pytest~=4.5.0
+    pytest44: pytest~=4.4.0
+    pytest43: pytest~=4.3.0
 
     -r{toxinidir}/requirements-testing.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py27-pytest46,
-          py37-pytest{46,5,latest},
+envlist = py27-pytest4,
+          py37-pytest{4,latest},
           py{35,36}-pytestlatest
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
 deps =
     pytestlatest: pytest
-    pytest5: pytest~=5.0.0
-    pytest46: pytest~=4.6.0
+    pytest4: pytest~=4.6.0
 
     -r{toxinidir}/requirements-testing.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py27-pytest{36,37,38,39,310,4,41,42,43,44,45,46},
-          py37-pytest{36,37,38,39,310,4,41,42,43,44,45,46,5,latest},
+envlist = py27-pytest46,
+          py37-pytest{46,5,latest},
           py{35,36}-pytestlatest
 
 [testenv]
@@ -10,17 +10,6 @@ deps =
     pytestlatest: pytest
     pytest5: pytest~=5.0.0
     pytest46: pytest~=4.6.0
-    pytest45: pytest~=4.5.0
-    pytest44: pytest~=4.4.0
-    pytest43: pytest~=4.3.0
-    pytest42: pytest~=4.2.0
-    pytest41: pytest~=4.1.0
-    pytest4: pytest~=4.0.0
-    pytest310: pytest~=3.10.0
-    pytest39: pytest~=3.9.0
-    pytest38: pytest~=3.8.0
-    pytest37: pytest~=3.7.0
-    pytest36: pytest~=3.6.0
 
     -r{toxinidir}/requirements-testing.txt
 


### PR DESCRIPTION
# Python 3.4

Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for pytest-factoryboy from PyPI for September 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.7      |  45.44% |    17,493 |
| 3.6      |  31.35% |    12,071 |
| 2.7      |  17.05% |     6,563 |
| 3.5      |   4.80% |     1,847 |
| null     |   1.20% |       462 |
| 3.4      |   0.16% |        60 |
| 2.6      |   0.01% |         3 |
| Total    |         |    38,499 |

Date range: 2019-09-01 - 2019-09-30

Source: `pip install -U pypistats && pypistats python_minor pytest-factoryboy --last-month`

# pytest 3.6-4.5, 5.0

Also pytest 4.0-4.2 are failing on master:

* https://travis-ci.org/hugovk/pytest-factoryboy/builds/596168409

Remove all the old ones and only test against pytest 4.6 ([the last to support Python 2.7](https://docs.pytest.org/en/latest/py27-py34-deprecation.html)) and the latest version (currently 5.2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/85)
<!-- Reviewable:end -->
