### PR TITLE
update supported python and pytest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+---
 language: python
 dist: bionic
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install tox tox-travis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 Unreleased
 ----------
 
-- Drop support for Python 3.4.
-- Drop support for pytest < 4.3.
+- Add support for Python 3.9.
+- Drop support for Python 3.4, 3.5.
+- Add support for pytest 6.
+- Drop support for pytest < 4.6.
 
 
 2.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py27', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py27', 'py36', 'py37', 'py38']

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         "inflection",
         "factory_boy>=2.10.0",
-        "pytest>=4.3",
+        "pytest>=4.6",
         'funcsigs;python_version<"3.0"',
     ],
     # the following makes a plugin available to py.test

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     install_requires=[
         "inflection",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ distshare = {homedir}/.tox/distshare
 envlist = py27-pytest{43,44,45,46},
           py38-pytest{43,44,45,46,50,51,52,53,54,60,latest},
           py38-pytestlatest-linters,
-          py{35,36,37}-pytestlatest
+          py{36,37,39}-pytestlatest
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py27-pytest{43,44,45,46},
-          py38-pytest{43,44,45,46,50,51,52,53,54,60,latest},
+envlist = py27-pytest46,
+          py38-pytest{46,54,60,61,62,latest,master},
           py38-pytestlatest-linters,
           py{36,37,39}-pytestlatest
 
@@ -9,22 +9,22 @@ envlist = py27-pytest{43,44,45,46},
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
 deps =
     pytestlatest: pytest
+    pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
+    pytest62: pytest~=6.2.0
+    pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0
     pytest54: pytest~=5.4.0
-    pytest53: pytest~=5.3.0
-    pytest52: pytest~=5.2.0
-    pytest51: pytest~=5.1.0
-    pytest50: pytest~=5.0.0
     pytest46: pytest~=4.6.0
-    pytest45: pytest~=4.5.0
-    pytest44: pytest~=4.4.0
-    pytest43: pytest~=4.3.0
 
     -r{toxinidir}/requirements-testing.txt
 
 [testenv:py38-pytestlatest-linters]
 deps = black
 commands = black --check --verbose setup.py pytest_factoryboy tests
+
+[testenv:py38-pytestmaster]
+# allow failures of tests run for `pytest` installed from `master` branch
+ignore_outcome = true
 
 [pytest]
 addopts = -vv -l

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py27-pytest46,
-          py38-pytest{46,54,60,61,62,latest,master},
+          py38-pytest{46,50,51,52,53,54,60,61,62,latest,master},
           py38-pytestlatest-linters,
           py{36,37,39}-pytestlatest
 
@@ -14,6 +14,10 @@ deps =
     pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0
     pytest54: pytest~=5.4.0
+    pytest53: pytest~=5.3.0
+    pytest52: pytest~=5.2.0
+    pytest51: pytest~=5.1.0
+    pytest50: pytest~=5.0.0
     pytest46: pytest~=4.6.0
 
     -r{toxinidir}/requirements-testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,3 @@ ignore_outcome = true
 
 [pytest]
 addopts = -vv -l
-pep8maxlinelength = 120


### PR DESCRIPTION
This PR:

+ adds Python 3.9 to supported python versions (add classifiers to `setup.py` and run tests)
+ removes python 3.5 from supported python versions
+ sync `pytest` versions supported by `pytest-factoryboy` with these officially maintained by `pytest-dev` team (I get versions from branch list of `pytest` repo)
+ remove invalid (or no longer used/needed) `pep8maxlinelength` pytest's ini option

What do you think about dropping support for python 2?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-factoryboy/104)
<!-- Reviewable:end -->
