### PR TITLE
Support LazyFixtures as declarations in factory class fixtures

### DIFF
--- a/tests/test_factory_fixtures.py
+++ b/tests/test_factory_fixtures.py
@@ -99,7 +99,7 @@ register(EditionFactory)
 
 def test_factory(book_factory):
     """Test model factory fixture."""
-    assert book_factory == BookFactory
+    assert issubclass(book_factory, BookFactory)
 
 
 def test_model(book):


### PR DESCRIPTION
# Brief

This PR adds support for using `LazyFixture` as a declaration directly in the factory, when using the factory class fixture. This makes the following possible:

```py
import factory
import pytest

from pytest_factoryboy import LazyFixture, register


class MyDictFactory(factory.DictFactory):
    apples = LazyFixture("pears")


register(MyDictFactory)


@pytest.fixture()
def pears():
    return "pears"


def test_my_apples(my_dict_factory):
    my_dict = my_dict_factory()
    assert my_dict == {"apples": "pears"}
```


# Description

Under the hood, factory class fixtures now return a subclass of the factory class (instead of the exact factory class that was registered). This subclass adds the pytest `request` fixture as a Params declaration — essentially doing this:
```py
class WrappedMyDictFactory(MyDictFactory):
    class Params:
        pytest_request = actual_pytest_request
```

`LazyFixture` now inherits from `factory.declarations.BaseDeclaration`. Its `evaluate` method has been overloaded to support both direct invocation from pytest-factoryboy when evaluating a model fixture, and invocation by factory_boy during factory class building.

When `LazyFixture.evaluate` is invoked for a model fixture, the pytest request is passed in directly; however, when invoked by factory_boy, the `pytest_request` is pulled from the factory's Params.