### PR TITLE
update supported python and pytest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
+---
 name: Main testing workflow
-
 on:
   push:
   pull_request:
@@ -7,11 +7,14 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: 
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
     - uses: actions/checkout@v2
@@ -25,5 +28,4 @@ jobs:
         pip install -U setuptools
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: |
-        tox
+      run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11"
+          - "3.11-dev"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ classifiers =
     Topic :: Software Development :: Libraries
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 python_requires = >=3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.6
 install_requires =
     inflection
     factory_boy>=2.10.0
-    pytest>=4.6
+    pytest>=6.0
 tests_require = tox
 packages = pytest_factoryboy
 include_package_data = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py38-pytest{46,50,51,52,53,54,60,61,62,latest,main},
+envlist = py38-pytest{46,50,51,52,53,54,60,61,62,70,latest,main},
           py{37,39,310}-pytestlatest
 
 [testenv]
@@ -8,6 +8,7 @@ commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
 deps =
     pytestlatest: pytest
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main
+    pytest70: pytest~=7.0.0
     pytest62: pytest~=6.2.0
     pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py38-pytest{46,50,51,52,53,54,60,61,62,latest,main},
-          py{36,37,39,310}-pytestlatest
+          py{37,39,310}-pytestlatest
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}
@@ -33,7 +33,6 @@ addopts = -vv -l
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ deps =
 # allow failures of tests run for `pytest` installed from `main` branch
 ignore_outcome = true
 
-[testenv:py310-pytestlatest]
-# allow failures of tests run with unstable python 3.10
+[testenv:py311-pytestlatest]
+# allow failures of tests run with unstable python 3.11
 ignore_outcome = true
 
 [pytest]
@@ -38,3 +38,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py38-pytest{46,50,51,52,53,54,60,61,62,70,latest,main},
+envlist = py38-pytest{60,61,62,70,latest,main},
           py{37,39,310}-pytestlatest
 
 [testenv]
@@ -12,12 +12,6 @@ deps =
     pytest62: pytest~=6.2.0
     pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0
-    pytest54: pytest~=5.4.0
-    pytest53: pytest~=5.3.0
-    pytest52: pytest~=5.2.0
-    pytest51: pytest~=5.1.0
-    pytest50: pytest~=5.0.0
-    pytest46: pytest~=4.6.0
 
     -r{toxinidir}/requirements-testing.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py38-pytest{60,61,62,70,latest,main},
-          py{37,39,310}-pytestlatest
+          py{37,39,310,311}-pytestlatest
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs:tests}


### PR DESCRIPTION
Hi :wave: 

This PR do the following things:

+ drops Python 3.6 support
+ adds Python 3.10 support (duplicates https://github.com/pytest-dev/pytest-factoryboy/pull/128)
+ runs tests against unstable Python 3.11
+ drops pytest<6.0 support (if you think we should support older pytest versions let's discuss that)
+ adds pytest^=7.0.0 support
