### PR TITLE
Fix _after_postgeneration results parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Drop support for Python 3.6. We now support only python >= 3.7.
 - Improve "debuggability". Internal pytest-factoryboy calls are now visible when using a debugger like PDB or PyCharm.
 - Add type annotations. Now `register` and `LazyFixture` are type annotated.
+- Fix `_after_postgeneration` not getting the evaluated post_generations and RelatedFactory results correctly in the `result` param.
 
 
 2.1.0

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -278,9 +278,8 @@ def make_deferred_related(factory: FactoryType, fixture: str, attr: str) -> Defe
     """
     name = SEPARATOR.join((fixture, attr))
 
-    def deferred_impl(request: FixtureRequest) -> None:
-        # TODO: Shouldn't we return this result?
-        request.getfixturevalue(name)
+    def deferred_impl(request: FixtureRequest) -> Any:
+        return request.getfixturevalue(name)
 
     return DeferredFunction(
         name=name,
@@ -312,9 +311,8 @@ def make_deferred_postgen(
     """
     name = SEPARATOR.join((fixture, attr))
 
-    def deferred_impl(request: FixtureRequest) -> None:
-        # TODO: Shouldn't we return this result?
-        declaration.call(instance, step, context)
+    def deferred_impl(request: FixtureRequest) -> Any:
+        return declaration.call(instance, step, context)
 
     return DeferredFunction(
         name=name,


### PR DESCRIPTION
The `result` parameter was not receiving the values of the evaluated postgens correctly (they were always None).
Now the `result` parameter is populated correctly.

Checklist:

- [x] merge https://github.com/pytest-dev/pytest-factoryboy/pull/139 first