### PR TITLE
Remove Table of Contents from the doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,6 @@
 Welcome to pytest-factoryboy's documentation!
 =============================================
 
-.. contents::
-
 .. include:: ../README.rst
 
 .. include:: ../AUTHORS.rst


### PR DESCRIPTION
It's already on the left menu, no need to have a long table of contents with all the changelog in the initial text.