### PR TITLE
Restrict register(...) usage

### DIFF
--- a/tests/test_factory_fixtures.py
+++ b/tests/test_factory_fixtures.py
@@ -217,16 +217,3 @@ def test_register_class_decorator_with_kwargs_only(harry_potter_author: Author):
     assert harry_potter_author.user
     assert harry_potter_author.user.username == "jk_rowling"
 
-
-register(_name="the_chronicles_of_narnia_author", name="C.S. Lewis")(
-    AuthorFactory,
-    register_user="cs_lewis",
-    register_user__password="Aslan1",
-)
-
-
-def test_register_function_with_kwargs_only(the_chronicles_of_narnia_author: Author):
-    """Ensure ``register`` function called with kwargs only works normally."""
-    assert the_chronicles_of_narnia_author.name == "C.S. Lewis"
-    assert the_chronicles_of_narnia_author.user
-    assert the_chronicles_of_narnia_author.user.password == "Aslan1"

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import factory
+import pytest
+from _pytest.fixtures import FixtureLookupError
+
+from pytest_factoryboy import register
+
+
+@dataclass(eq=False)
+class Foo:
+    value: str
+
+
+class TestRegisterDirectDecorator:
+    @register()
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = "@register()"
+
+    def test_register(self, foo: Foo):
+        """Test that `register` can be used as a decorator with 0 arguments."""
+        assert foo.value == "@register()"
+
+
+class TestRegisterDecoratorNoArgs:
+    @register
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = "@register"
+
+    def test_register(self, foo: Foo):
+        """Test that `register` can be used as a direct decorator."""
+        assert foo.value == "@register"
+
+
+class TestRegisterDecoratorWithArgs:
+    @register(value="bar")
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = None
+
+    def test_register(self, foo: Foo):
+        """Test that `register` can be used as a decorator with arguments overriding the factory declarations."""
+        assert foo.value == "bar"
+
+
+class TestRegisterAlternativeName:
+    @register(_name="second_foo")
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = None
+
+    def test_register(self, request, second_foo: Foo):
+        """Test that `register` invoked with a specific `_name` registers the fixture under that `_name`."""
+        assert second_foo.value == None
+
+        with pytest.raises(FixtureLookupError) as exc:
+            request.getfixturevalue("foo")
+        assert exc.value.argname == "foo"
+
+
+class TestRegisterAlternativeNameAndArgs:
+    @register(_name="second_foo", value="second_bar")
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = None
+
+    def test_register(self, second_foo: Foo):
+        """Test that `register` can be invoked with `_name` to specify an alternative
+        fixture name and with any kwargs to override the factory declarations."""
+        assert second_foo.value == "second_bar"
+
+
+class TestRegisterCall:
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = "register(FooFactory)"
+
+    register(FooFactory)
+    register(FooFactory, _name="second_foo", value="second_bar")
+
+    def test_register(self, foo: Foo, second_foo: Foo):
+        """Test that `register` can be invoked directly."""
+        assert foo.value == "register(FooFactory)"
+        assert second_foo.value == "second_bar"


### PR DESCRIPTION
We recently introduced the option to use `@register(...)` as a decorator with arguments.
The [implemented solution](https://github.com/pytest-dev/pytest-factoryboy/pull/138) allows the kwargs to be redefined after the initial call, since we returned a functools.partial object.

I'm currently working on a [new-style register](https://github.com/pytest-dev/pytest-factoryboy/pull/150), and having this restricted usage would make it easier for the migration path (I'm trying to rewrite the source files of the caller, so that users wouldn't have to manually rewrite all their usages of `@register`)