### PR TITLE
Refactor FixtureDef generation logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ disallow_untyped_decorators = true
 disallow_any_explicit = false
 disallow_any_generics = true
 disallow_untyped_calls = true
+disallow_untyped_defs = true
 ignore_errors = false
 ignore_missing_imports = true
 implicit_reexport = false
@@ -33,3 +34,4 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_decorators = false
+disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ warn_redundant_casts = true
 warn_unused_configs = true
 warn_unreachable = true
 warn_no_return = true
+warn_return_any = true
 pretty = true
 show_error_codes = true
 

--- a/pytest_factoryboy/codegen.py
+++ b/pytest_factoryboy/codegen.py
@@ -32,7 +32,7 @@ class FixtureDef:
     related: list[str] = field(default_factory=list)
 
     @property
-    def kwargs_var_name(self):
+    def kwargs_var_name(self) -> str:
         return f"_{self.name}__kwargs"
 
 
@@ -92,7 +92,7 @@ def make_temp_folder(package_name: str) -> pathlib.Path:
 
 
 @lru_cache()  # This way we reuse the same folder for the whole execution of the program
-def create_package(package_name: str, init_py_content=init_py_content) -> pathlib.Path:
+def create_package(package_name: str, init_py_content: str = init_py_content) -> pathlib.Path:
     path = cache_dir / package_name
     try:
         if path.exists():
@@ -130,7 +130,7 @@ def make_module(code: str, module_name: str, package_name: str) -> ModuleType:
     return mod
 
 
-def make_fixture_model_module(model_name, fixture_defs: list[FixtureDef]):
+def make_fixture_model_module(model_name: str, fixture_defs: list[FixtureDef]) -> ModuleType:
     code = module_template.render(fixture_defs=fixture_defs)
     generated_module = make_module(code, module_name=model_name, package_name="_pytest_factoryboy_generated_fixtures")
     for fixture_def in fixture_defs:

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -104,7 +104,7 @@ def register(
 
 
 def collect_fixturedefs(
-    factory_class: FactoryType, model_name: str, overrides: Mapping[str, Any], caller_locals: dict[str, Any]
+    factory_class: FactoryType, model_name: str, overrides: Mapping[str, Any], caller_locals: Mapping[str, Any]
 ) -> Iterable[FixtureDef]:
     factory_name = get_factory_name(factory_class)
 

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -187,16 +187,15 @@ def make_attribute_fixturedef(
 
     if isinstance(factory_value, factory.PostGeneration):
         value = None
+        deps = []
     elif isinstance(factory_value, factory.PostGenerationMethodCall):
         value = factory_value.method_arg
-    else:
+        deps = []
+    elif isinstance(factory_value, LazyFixture):
         value = factory_value
-
-    # Do we want to allow to specify LazyFixture in the Factory class definition? Probably not
-    # TODO: if so, remove this
-    if isinstance(value, LazyFixture):
         deps = value.args
     else:
+        value = factory_value
         deps = []
 
     return FixtureDef(

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -170,6 +170,7 @@ def make_attribute_fixturedef(
             deps=args,
         )
 
+    deps: list[str]  # makes mypy happy
     if isinstance(value, factory.PostGeneration):
         value = None
         deps = []

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from inspect import signature
-from typing import TYPE_CHECKING, Type, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Type, cast, overload
 
 import factory
 import factory.builder
@@ -12,6 +12,7 @@ import factory.declarations
 import factory.enums
 import inflection
 from factory.declarations import NotProvided
+from typing_extensions import TypeAlias
 
 from .codegen import FixtureDef, make_fixture_model_module
 from .compat import PostGenerationContext

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from inspect import signature
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, Type, TypeAlias, cast, overload
 
 import factory
 import factory.builder
@@ -16,8 +16,10 @@ from factory.declarations import NotProvided
 from .codegen import FixtureDef, make_fixture_model_module
 from .compat import PostGenerationContext
 
+FactoryType: TypeAlias = Type[factory.Factory]
+
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, Mapping, TypeAlias, TypeVar
+    from typing import Any, Callable, Iterable, Mapping, TypeVar
 
     from _pytest.fixtures import FixtureFunction, SubRequest
     from factory.builder import BuildStep
@@ -25,7 +27,6 @@ if TYPE_CHECKING:
 
     from .plugin import Request as FactoryboyRequest
 
-    FactoryType: TypeAlias = type[factory.Factory]
     T = TypeVar("T")
     F = TypeVar("F", bound=FactoryType)
 

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -88,7 +88,7 @@ def register(
     model_name = get_model_name(factory_class) if _name is None else _name
 
     fixture_defs = list(
-        collect_fixturedefs(
+        generate_fixturedefs(
             factory_class=factory_class, model_name=model_name, overrides=kwargs, caller_locals=_caller_locals
         )
     )
@@ -103,9 +103,10 @@ def register(
     return factory_class
 
 
-def collect_fixturedefs(
+def generate_fixturedefs(
     factory_class: FactoryType, model_name: str, overrides: Mapping[str, Any], caller_locals: Mapping[str, Any]
 ) -> Iterable[FixtureDef]:
+    """Generate all the FixtureDefs for the given factory class."""
     factory_name = get_factory_name(factory_class)
 
     related: list[str] = []
@@ -113,7 +114,7 @@ def collect_fixturedefs(
         value = overrides.get(attr, value)
         attr_name = SEPARATOR.join((model_name, attr))
         yield (
-            make_attribute_fixturedef(
+            make_declaration_fixturedef(
                 attr_name=attr_name,
                 value=value,
                 factory_class=factory_class,
@@ -142,12 +143,13 @@ def collect_fixturedefs(
     )
 
 
-def make_attribute_fixturedef(
+def make_declaration_fixturedef(
     attr_name: str,
     value: Any,
     factory_class: FactoryType,
     related: list[str],
 ) -> FixtureDef:
+    """Create the FixtureDef for a factory declaration."""
     if isinstance(value, (factory.SubFactory, factory.RelatedFactory)):
         subfactory_class = value.get_factory()
         subfactory_deps = get_deps(subfactory_class, factory_class)

--- a/tests/test_lazy_fixture.py
+++ b/tests/test_lazy_fixture.py
@@ -53,3 +53,17 @@ def test_lazy_attribute(user: User):
 def test_lazy_attribute_partial(partial_user: User):
     """Test LazyFixture value is extracted before the LazyAttribute is called. Partial."""
     assert partial_user.is_active
+
+
+class TestLazyFixtureDeclaration:
+    @pytest.fixture
+    def name(self):
+        return "from fixture name"
+
+    @register(_name="test_user")
+    class UserFactory(UserFactory):
+        username = LazyFixture("name")
+
+    def test_lazy_fixture_declaration(self, test_user):
+        """Test that we can use the LazyFixture declaration in the factory itself."""
+        assert test_user.username == "from fixture name"

--- a/tests/test_lazy_fixture.py
+++ b/tests/test_lazy_fixture.py
@@ -60,10 +60,15 @@ class TestLazyFixtureDeclaration:
     def name(self):
         return "from fixture name"
 
-    @register(_name="test_user")
-    class UserFactory(UserFactory):
-        username = LazyFixture("name")
+    @register
+    class UserFactory(factory.Factory):
+        class Meta:
+            model = User
 
-    def test_lazy_fixture_declaration(self, test_user):
+        username = LazyFixture("name")
+        password = "foo"
+        is_active = False
+
+    def test_lazy_fixture_declaration(self, user):
         """Test that we can use the LazyFixture declaration in the factory itself."""
-        assert test_user.username == "from fixture name"
+        assert user.username == "from fixture name"

--- a/tests/test_postgen_dependencies.py
+++ b/tests/test_postgen_dependencies.py
@@ -94,7 +94,7 @@ class BarFactory(factory.Factory):
     @classmethod
     def _create(cls, model_class: type[Bar], foo: Foo) -> Bar:
         assert foo.value == foo.expected
-        bar = super()._create(model_class, foo=foo)
+        bar: Bar = super()._create(model_class, foo=foo)
         foo.bar = bar
         return bar
 


### PR DESCRIPTION
Refactor the generation of the FixtureDefs for a factory.
The code is now way more simple, and the big chunk of code that creates the FixtureDef is extracted into its own function.

A side effect of this change is that we legislate the usage of LazyFixture in a Factory declaration. For example, this code is now fully supported:

```python
@pytest.fixture
def name():
    return "John"

@register
class UserFactory(factory.Factory):
    username = LazyFixture("name")

def test_name(user):
    assert user.name == "John"
```

This can be useful for small factories that are needed just for individual test modules, and that won't ever be used without a pytest context.