### PR TITLE
Determine the fixture name using the factory name, rather than the model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+- The fixture name for registered factories is now determined by the factory name (rather than the model name). This makes factories for builtin types (like ``dict``) easier to use.
 
 2.4.0
 ----------

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,6 @@ You may want to use this if your factory name does not follow the naming convent
 
     @register  # book
     @register(_name="second_book")  # second_book
-    @register(_name="other_book")  # other_book, book of another author
     class BookFactory(factory.Factory):
         class Meta:
             model = Book

--- a/README.rst
+++ b/README.rst
@@ -35,35 +35,11 @@ Concept
 Library exports a function to register factories as fixtures. Fixtures are contributed
 to the same module where register function is called.
 
-Factory Fixture
----------------
-
-Factory fixtures allow using factories without importing them. Name convention is lowercase-underscore
-class name.
-
-.. code-block:: python
-
-    import factory
-    from pytest_factoryboy import register
-
-    class AuthorFactory(factory.Factory):
-        class Meta:
-            model = Author
-
-
-    register(AuthorFactory)
-
-
-    def test_factory_fixture(author_factory):
-        author = author_factory(name="Charles Dickens")
-        assert author.name == "Charles Dickens"
-
-
 Model Fixture
 -------------
 
-Model fixture implements an instance of a model created by the factory. Name convention is model's lowercase-underscore
-class name.
+Model fixture implements an instance of a model created by the factory. The fixture name is determined by the factory name.
+For example, if the factory name is ``MyAuthorFactory``, the fixture name is ``my_author``.
 
 
 .. code-block:: python
@@ -83,8 +59,8 @@ class name.
         assert author.name == "Charles Dickens"
 
 
-Model fixtures can be registered with specific names. For example, if you address instances of some collection
-by the name like "first", "second" or of another parent as "other":
+Model fixtures can be registered with specific names.
+You may want to use this if your factory name does not follow the naming convention, or if you need multiple model fixtures for the same factory:
 
 
 .. code-block:: python
@@ -92,7 +68,6 @@ by the name like "first", "second" or of another parent as "other":
     register(AuthorFactory)  # author
     register(AuthorFactory, "second_author")  # second_author
 
-    # `register(...)` can be used as a decorator too
     @register  # book
     @register(_name="second_book")  # second_book
     @register(_name="other_book")  # other_book, book of another author
@@ -101,11 +76,19 @@ by the name like "first", "second" or of another parent as "other":
             model = Book
 
 
-    @pytest.fixture
-    def other_book__author(second_author):
-        """Make the relation of the second_book to another (second) author."""
-        return second_author
+The ``register`` function can be used both as a decorator and as a function. It will register the fixtures in the module/class where it's invoked.
 
+.. code-block:: python
+
+    # register used as a function:
+    register(AuthorFactory)  # `author` is now a fixture of this module
+    register(AuthorFactory, "second_author")  # `second_author` too
+
+    # register used as a decorator:
+    @register  # `book` is now a fixture of this module.
+    class BookFactory(factory.Factory):
+        class Meta:
+            model = Book
 
 
 Attributes are Fixtures

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ pytest-factoryboy makes it easy to combine ``factory`` approach to the test setu
 heart of the `pytest fixtures`_.
 
 .. _factory_boy: https://factoryboy.readthedocs.io
-.. _pytest: http://pytest.org
+.. _pytest: https://pytest.org
 .. _pytest fixtures: https://pytest.org/latest/fixture.html
-.. _overridden: http://pytest.org/latest/fixture.html#override-a-fixture-with-direct-test-parametrization
+.. _overridden: https://docs.pytest.org/en/latest/how-to/fixtures.html#overriding-fixtures-on-various-levels
 
 
 Install pytest-factoryboy

--- a/poetry.lock
+++ b/poetry.lock
@@ -322,7 +322,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "e95030e079732fd1cbe8c25bd8f093f1e381e06980cfbd0d9421fafb1a5ac483"
+content-hash = "367f18a04dc939a2eaf30c18def779c7608091821a9877371a69a5c18e5eb3b0"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ typing_extensions = "*"
 [tool.poetry.dev-dependencies]
 mypy = "^0.960"
 tox = "^3.25.0"
+packaging = "^21.3"
+importlib-metadata = { version = "^4.11.4", python = "<3.8" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -239,11 +239,18 @@ def inject_into_caller(name: str, function: Callable[..., Any], locals_: dict[st
 
 def get_model_name(factory_class: FactoryType) -> str:
     """Get model fixture name by factory."""
-    return (
-        inflection.underscore(factory_class._meta.model.__name__)
-        if not isinstance(factory_class._meta.model, str)
-        else factory_class._meta.model
-    )
+    # "class AuthorFactory(...):" -> "author"
+    suffix = "Factory"
+    if factory_class.__name__.endswith(suffix):
+        factory_name = factory_class.__name__[: -len(suffix)]
+        return inflection.underscore(factory_name)
+    else:
+        raise ValueError(
+            f"Factory {factory_class} does not follow the '<model_name>Factory' naming convention and "
+            "pytest-factoryboy cannot automatically determine the fixture name.\n"
+            f"Please use the naming convention '<model_name>Factory' or explicitly set the fixture name "
+            "using `@register(_name=...)`."
+        )
 
 
 def get_factory_name(factory_class: FactoryType) -> str:

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+
+from _pytest.pytester import RunResult
+from packaging.version import Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+PYTEST_VERSION = Version(metadata.version("pytest"))
+
+if PYTEST_VERSION >= Version("6.0.0"):
+
+    def assert_outcomes(
+        result: RunResult,
+        passed: int = 0,
+        skipped: int = 0,
+        failed: int = 0,
+        errors: int = 0,
+        xpassed: int = 0,
+        xfailed: int = 0,
+    ) -> None:
+        """Compatibility function for result.assert_outcomes"""
+        result.assert_outcomes(
+            errors=errors,
+            passed=passed,
+            skipped=skipped,
+            failed=failed,
+            xpassed=xpassed,
+            xfailed=xfailed,
+        )
+
+else:
+
+    def assert_outcomes(
+        result: RunResult,
+        passed: int = 0,
+        skipped: int = 0,
+        failed: int = 0,
+        errors: int = 0,
+        xpassed: int = 0,
+        xfailed: int = 0,
+    ) -> None:
+        """Compatibility function for result.assert_outcomes"""
+        result.assert_outcomes(
+            error=errors,  # Pytest < 6 uses the singular form
+            passed=passed,
+            skipped=skipped,
+            failed=failed,
+            xpassed=xpassed,
+            xfailed=xfailed,
+        )

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -52,4 +52,4 @@ else:
             failed=failed,
             xpassed=xpassed,
             xfailed=xfailed,
-        )
+        )  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytester"

--- a/tests/test_factory_name.py
+++ b/tests/test_factory_name.py
@@ -22,12 +22,16 @@ def test_fixture_name_cant_be_determined(pytester):
     """Test that an error is raised if the fixture name can't be determined."""
     pytester.makepyfile(
         """
-        from tests.test_model_name import JSONPayloadFactory
+        import factory
         from pytest_factoryboy import register
 
         @register
-        class JSONPayloadF(JSONPayloadFactory):
-            pass
+        class JSONPayloadF(factory.Factory):
+            class Meta:
+                model = dict
+
+            name = "John Doe"
+
         """
     )
     res = pytester.runpytest()
@@ -39,12 +43,16 @@ def test_invalid_factory_name_override(pytester):
     """Test that, although the factory name doesn't follow the naming convention, it can still be overridden."""
     pytester.makepyfile(
         """
-        from tests.test_model_name import JSONPayloadFactory
+        import factory
         from pytest_factoryboy import register
 
         @register(_name="payload")
-        class JSONPayloadF(JSONPayloadFactory):
-            pass
+        class JSONPayloadF(factory.Factory):
+            class Meta:
+                model = dict
+
+            name = "John Doe"
+
 
         def test_payload(payload):
             assert payload["name"] == "John Doe"

--- a/tests/test_factory_name.py
+++ b/tests/test_factory_name.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import factory
 
 from pytest_factoryboy import register
+from tests.compat import assert_outcomes
 
 
 @register
@@ -35,7 +36,7 @@ def test_fixture_name_cant_be_determined(pytester):
         """
     )
     res = pytester.runpytest()
-    res.assert_outcomes(errors=1)
+    assert_outcomes(res, errors=1)
     res.stdout.fnmatch_lines("*JSONPayloadF *does not follow*naming convention*")
 
 
@@ -59,4 +60,4 @@ def test_invalid_factory_name_override(pytester):
         """
     )
     res = pytester.runpytest()
-    res.assert_outcomes(passed=1)
+    assert_outcomes(res, passed=1)

--- a/tests/test_factory_name.py
+++ b/tests/test_factory_name.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import factory
+
+from pytest_factoryboy import register
+
+
+@register
+class JSONPayloadFactory(factory.Factory):
+    class Meta:
+        model = dict
+
+    name = "John Doe"
+
+
+def test_fixture_name_as_expected(json_payload):
+    """Test that the json_payload fixture is registered from the JSONPayloadFactory."""
+    assert json_payload["name"] == "John Doe"
+
+
+def test_fixture_name_cant_be_determined(pytester):
+    """Test that an error is raised if the fixture name can't be determined."""
+    pytester.makepyfile(
+        """
+        from tests.test_model_name import JSONPayloadFactory
+        from pytest_factoryboy import register
+
+        @register
+        class JSONPayloadF(JSONPayloadFactory):
+            pass
+        """
+    )
+    res = pytester.runpytest()
+    res.assert_outcomes(errors=1)
+    res.stdout.fnmatch_lines("*JSONPayloadF *does not follow*naming convention*")
+
+
+def test_invalid_factory_name_override(pytester):
+    """Test that, although the factory name doesn't follow the naming convention, it can still be overridden."""
+    pytester.makepyfile(
+        """
+        from tests.test_model_name import JSONPayloadFactory
+        from pytest_factoryboy import register
+
+        @register(_name="payload")
+        class JSONPayloadF(JSONPayloadFactory):
+            pass
+
+        def test_payload(payload):
+            assert payload["name"] == "John Doe"
+        """
+    )
+    res = pytester.runpytest()
+    res.assert_outcomes(passed=1)


### PR DESCRIPTION
Often I make factories for a `dict`, and it's getting annoying that by default the fixture name is `"dict"`.
This PR changes it to use the factory name to determine the fixture name.
For example, this factory
```python
@register
class HTTPHeadersFactory(factory.Factory):
    class Meta:
        model = dict

    Authorization = "Basic Zm9vOmJhcg=="
```

will now register a fixture called `http_headers`, instead of `dict`.