### PR TITLE
Fix _after_postgeneration being invoked twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-- The fixture name for registered factories is now determined by the factory name (rather than the model name). This makes factories for builtin types (like ``dict``) easier to use. `#163 <https://github.com/pytest-dev/pytest-factoryboy/pull/163>`_
+- The generated fixture name is now determined by the factory (rather than the model). This makes factories for builtin types (like ``dict``) easier to use. You may need to change your factories to use the ``<model>Factory`` naming convention, or use the ``register(_name=...)`` override. `#163 <https://github.com/pytest-dev/pytest-factoryboy/pull/163>`_
 
 .. code-block:: python
 
@@ -18,7 +18,6 @@ Unreleased
 
     def test_headers(headers):
         assert headers["Authorization"] == "Basic Zm9vOmJhcg=="
-
 
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog
 
 Unreleased
 ----------
-- The fixture name for registered factories is now determined by the factory name (rather than the model name). This makes factories for builtin types (like ``dict``) easier to use.
+- The fixture name for registered factories is now determined by the factory name (rather than the model name). This makes factories for builtin types (like ``dict``) easier to use. `#163 <https://github.com/pytest-dev/pytest-factoryboy/pull/163>`_
+- Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 
 2.4.0
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,22 @@ Changelog
 Unreleased
 ----------
 - The fixture name for registered factories is now determined by the factory name (rather than the model name). This makes factories for builtin types (like ``dict``) easier to use. `#163 <https://github.com/pytest-dev/pytest-factoryboy/pull/163>`_
+
+.. code-block:: python
+
+    # example
+    @register
+    class HTTPHeadersFactory(factory.Factory):
+        class Meta:
+            model = dict  # no need to use a special dict subclass anymore
+
+        Authorization = "Basic Zm9vOmJhcg=="
+
+
+    def test_headers(headers):
+        assert headers["Authorization"] == "Basic Zm9vOmJhcg=="
+
+
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 
 2.4.0

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -452,9 +452,9 @@ def subfactory_fixture(request: SubRequest, factory_class: FactoryType) -> Any:
     return request.getfixturevalue(fixture)
 
 
-def get_caller_locals(depth: int = 2) -> dict[str, Any]:
+def get_caller_locals(depth: int = 0) -> dict[str, Any]:
     """Get the local namespace of the caller frame."""
-    return sys._getframe(depth).f_locals
+    return sys._getframe(depth + 2).f_locals
 
 
 class LazyFixture(Generic[T]):

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -24,7 +24,6 @@ import factory.builder
 import factory.declarations
 import factory.enums
 import inflection
-from factory.declarations import NotProvided
 from typing_extensions import ParamSpec, TypeAlias
 
 from .compat import PostGenerationContext
@@ -32,8 +31,6 @@ from .fixturegen import create_fixture
 
 if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
-    from factory.builder import BuildStep
-    from factory.declarations import PostGeneration, PostGenerationContext
 
     from .plugin import Request as FactoryboyRequest
 
@@ -366,7 +363,7 @@ def model_fixture(request: SubRequest, factory_name: str) -> Any:
             # that `value_provided` should be falsy
             postgen_value = evaluate(request, request.getfixturevalue(argname))
             postgen_context = PostGenerationContext(
-                value_provided=(postgen_value is not NotProvided),
+                value_provided=(postgen_value is not factory.declarations.NotProvided),
                 value=postgen_value,
                 extra=extra,
             )
@@ -404,12 +401,12 @@ def make_deferred_related(factory: FactoryType, fixture: str, attr: str) -> Defe
 
 
 def make_deferred_postgen(
-    step: BuildStep,
+    step: factory.builder.BuildStep,
     factory_class: FactoryType,
     fixture: str,
     instance: Any,
     attr: str,
-    declaration: PostGeneration,
+    declaration: factory.declarations.PostGenerationDeclaration,
     context: PostGenerationContext,
 ) -> DeferredFunction:
     """Make deferred function for the post-generation declaration.
@@ -419,6 +416,7 @@ def make_deferred_postgen(
     :param fixture: Object fixture name e.g. "author".
     :param instance: Parent object instance.
     :param attr: Declaration attribute name e.g. "register_user".
+    :param declaration: Post-generation declaration.
     :param context: Post-generation declaration context.
 
     :note: Deferred function name results in "author__register_user".

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -268,7 +268,6 @@ def get_deps(
     :return: List of the fixture argument names for dependency injection.
     """
     model_name = get_model_name(factory_class) if model_name is None else model_name
-    # TODO: This does not take into account the custom _name. Fix it.
     parent_model_name = get_model_name(parent_factory_class) if parent_factory_class is not None else None
 
     def is_dep(value: Any) -> bool:


### PR DESCRIPTION
Partially fixes https://github.com/pytest-dev/pytest-factoryboy/issues/156.