### PR TITLE
Add `named_model` function and raise warning for factories using generic models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-- Using a generic class container like ``dict``, ``list``, ``set``, etc. will raise a warning suggesting you to wrap your model using ``named_model(...)``. Doing this will make sure that the fixture name is correctly chosen, otherwise SubFactory and RelatedFactory aren't able to determine the name of the model. See TODO
+- Using a generic class container like ``dict``, ``list``, ``set``, etc. will raise a warning suggesting you to wrap your model using ``named_model(...)``. Doing this will make sure that the fixture name is correctly chosen, otherwise SubFactory and RelatedFactory aren't able to determine the name of the model. See `Generic Container Classes as models <https://pytest-factoryboy.readthedocs.io/en/latest/#generic-container-classes-as-models>`_ `#167 <https://github.com/pytest-dev/pytest-factoryboy/pull/167>`_
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 
 2.4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+- TODO: Add changelog entry for named_model and warnings.
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 
 2.4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-- TODO: Add changelog entry for named_model and warnings.
+- Using a generic class container like ``dict``, ``list``, ``set``, etc. will raise a warning suggesting you to wrap your model using ``named_model(...)``. Doing this will make sure that the fixture name is correctly chosen, otherwise SubFactory and RelatedFactory aren't able to determine the name of the model. See TODO
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
 
 2.4.0

--- a/README.rst
+++ b/README.rst
@@ -281,6 +281,29 @@ LazyFixture constructor accepts either existing fixture name or callable with de
     register(BookFactory, "another_book", author=LazyFixture("another_author"))
 
 
+Generic container classes as models
+-----------------------------------
+It's often useful to create factories for ``dict``s or other common generic container classes.
+In that case, you should wrap the container class around ``named_model(...)``, so that pytest-factoryboy can correctly determine the model name when using it in a SubFactory or RelatedFactory.
+Pytest-factoryboy will otherwise raise a warning.
+
+For example:
+
+.. code-block:: python
+
+    import factory
+    from pytest_factoryboy import named_model, register
+
+    @register
+    class JSONPayload(factory.Factory):
+        class Meta:
+            model = named_model("JSONPayload", dict)
+            # instead of
+            # model = dict
+
+        ...
+
+
 Post-generation dependencies
 ============================
 

--- a/README.rst
+++ b/README.rst
@@ -300,9 +300,13 @@ For example:
         class Meta:
             model = named_model("JSONPayload", dict)
 
-        ...
+        name = "foo"
 
-As a bonus, factory is automatically registering the ``"json_payload"`` fixture (rather than ``"dict"``), so there is no need to override ``@register(_name="json_payload")).
+
+    def test_foo(json_payload):
+        assert json_payload.name == "foo"
+
+As a bonus, factory is automatically registering the ``json_payload`` fixture (rather than ``dict``), so there is no need to override ``@register(_name="json_payload"))``.
 
 Post-generation dependencies
 ============================

--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,7 @@ Generic container classes as models
 -----------------------------------
 It's often useful to create factories for ``dict`` or other common generic container classes.
 In that case, you should wrap the container class around ``named_model(...)``, so that pytest-factoryboy can correctly determine the model name when using it in a SubFactory or RelatedFactory.
+
 Pytest-factoryboy will otherwise raise a warning.
 
 For example:
@@ -298,11 +299,10 @@ For example:
     class JSONPayload(factory.Factory):
         class Meta:
             model = named_model("JSONPayload", dict)
-            # instead of
-            # model = dict
 
         ...
 
+As a bonus, factory is automatically registering the ``"json_payload"`` fixture (rather than ``"dict"``), so there is no need to override ``@register(_name="json_payload")).
 
 Post-generation dependencies
 ============================

--- a/README.rst
+++ b/README.rst
@@ -280,7 +280,6 @@ LazyFixture constructor accepts either existing fixture name or callable with de
     # Can also be used in the partial specialization during the registration.
     register(BookFactory, "another_book", author=LazyFixture("another_author"))
 
-.. _Generic container classes:
 
 Generic container classes as models
 -----------------------------------

--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ LazyFixture constructor accepts either existing fixture name or callable with de
 
 Generic container classes as models
 -----------------------------------
-It's often useful to create factories for ``dict``s or other common generic container classes.
+It's often useful to create factories for ``dict`` or other common generic container classes.
 In that case, you should wrap the container class around ``named_model(...)``, so that pytest-factoryboy can correctly determine the model name when using it in a SubFactory or RelatedFactory.
 Pytest-factoryboy will otherwise raise a warning.
 

--- a/README.rst
+++ b/README.rst
@@ -280,6 +280,7 @@ LazyFixture constructor accepts either existing fixture name or callable with de
     # Can also be used in the partial specialization during the registration.
     register(BookFactory, "another_book", author=LazyFixture("another_author"))
 
+.. _Generic container classes:
 
 Generic container classes as models
 -----------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -322,7 +322,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "dbcd7cf750723fb8d85f8b00435fb3a10e9a9333890a90666ef978a35b16904a"
+content-hash = "7aa07c6bfc86f1fb930decf1d5d7b8bf4de6ec368405e4d8bed5ff770de2d14b"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ typing_extensions = "*"
 [tool.poetry.dev-dependencies]
 mypy = "^0.960"
 tox = "^3.25.0"
+packaging = "^21.3"
+importlib-metadata = "^4.11.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest_factoryboy/__init__.py
+++ b/pytest_factoryboy/__init__.py
@@ -1,4 +1,4 @@
 """pytest-factoryboy public API."""
-from .fixture import LazyFixture, register
+from .fixture import LazyFixture, named_model, register
 
-__all__ = ("register", "LazyFixture")
+__all__ = ("register", "named_model", "LazyFixture")

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -257,9 +257,7 @@ def get_model_name(factory_class: FactoryType) -> str:
             f"Using a {model_cls} as model type for {factory_class} is discouraged by pytest-factoryboy, "
             f"as it assumes that the model name is {model_name!r} when using it as SubFactory or RelatedFactory, "
             f"which is too generic and probably not what you want.\n"
-            f"You can suppress this error by using:\n"
-            f'model = named_model({model_cls.__name__}, "{model_name}")\n'
-            f"or you can consider giving an explicit name to the model by using:\n"
+            f"You can giving an explicit name to the model by using:\n"
             f'model = named_model({model_cls.__name__}, "Foo")',
         )
 

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -256,8 +256,8 @@ def get_model_name(factory_class: FactoryType) -> str:
         warnings.warn(
             f"Using a {model_cls} as model type for {factory_class} is discouraged by pytest-factoryboy, "
             f"as it assumes that the model name is {model_name!r} when using it as SubFactory or RelatedFactory, "
-            f"which is too generic and probably not what you want.\n"
-            f"You can giving an explicit name to the model by using:\n"
+            "which is too generic and probably not what you want.\n"
+            "You can giving an explicit name to the model by using:\n"
             f'model = named_model({model_cls.__name__}, "Foo")',
         )
 

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import sys
+import warnings
 from dataclasses import dataclass
 from inspect import signature
 from types import MethodType
@@ -43,6 +44,7 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 SEPARATOR = "__"
+WARN_FOR_MODEL_TYPES = frozenset({dict, list, set, tuple, frozenset})
 
 
 @dataclass(eq=False)
@@ -54,6 +56,11 @@ class DeferredFunction:
 
     def __call__(self, request: SubRequest) -> Any:
         return self.function(request)
+
+
+def named_model(model_cls: type[T], name: str) -> type[T]:
+    """Return a model class with a given name."""
+    return type(name, (model_cls,), {})
 
 
 # register(AuthorFactory, ...)
@@ -239,11 +246,24 @@ def inject_into_caller(name: str, function: Callable[..., Any], locals_: dict[st
 
 def get_model_name(factory_class: FactoryType) -> str:
     """Get model fixture name by factory."""
-    return (
-        inflection.underscore(factory_class._meta.model.__name__)
-        if not isinstance(factory_class._meta.model, str)
-        else factory_class._meta.model
-    )
+    model_cls = factory_class._meta.model
+
+    if isinstance(model_cls, str):
+        return model_cls
+
+    model_name = inflection.underscore(model_cls.__name__)
+    if model_cls in WARN_FOR_MODEL_TYPES:
+        warnings.warn(
+            f"Using a {model_cls} as model type for {factory_class} is discouraged by pytest-factoryboy, "
+            f"as it assumes that the model name is {model_name!r} when using it as SubFactory or RelatedFactory, "
+            f"which is too generic and probably not what you want.\n"
+            f"You can suppress this error by using:\n"
+            f'model = named_model({model_cls.__name__}, "{model_name}")\n'
+            f"or you can consider giving an explicit name to the model by using:\n"
+            f'model = named_model({model_cls.__name__}, "Foo")',
+        )
+
+    return model_name
 
 
 def get_factory_name(factory_class: FactoryType) -> str:

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+
+from _pytest.pytester import RunResult
+from packaging.version import Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+PYTEST_VERSION = Version(metadata.version("pytest"))
+
+if PYTEST_VERSION >= Version("6.0.0"):
+
+    def assert_outcomes(
+        result: RunResult,
+        passed: int = 0,
+        skipped: int = 0,
+        failed: int = 0,
+        errors: int = 0,
+        xpassed: int = 0,
+        xfailed: int = 0,
+    ) -> None:
+        """Compatibility function for result.assert_outcomes"""
+        result.assert_outcomes(
+            errors=errors,
+            passed=passed,
+            skipped=skipped,
+            failed=failed,
+            xpassed=xpassed,
+            xfailed=xfailed,
+        )
+
+else:
+
+    def assert_outcomes(
+        result: RunResult,
+        passed: int = 0,
+        skipped: int = 0,
+        failed: int = 0,
+        errors: int = 0,
+        xpassed: int = 0,
+        xfailed: int = 0,
+    ) -> None:
+        """Compatibility function for result.assert_outcomes"""
+        result.assert_outcomes(
+            error=errors,  # Pytest < 6 uses the singular form
+            passed=passed,
+            skipped=skipped,
+            failed=failed,
+            xpassed=xpassed,
+            xfailed=xfailed,
+        )  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytester"

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -18,7 +18,7 @@ def test_generic_model_with_custom_name_no_warning(testdir):
         def test_payload(json_payload: dict):
             assert isinstance(json_payload, dict)
             assert json_payload["foo"] == "bar"
-    """
+        """
     )
     result = testdir.runpytest("-Werror")  # Warnings become errors
     assert_outcomes(result, passed=1)

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -1,4 +1,5 @@
 # TODO: Unit test get_model_name
+from tests.compat import assert_outcomes
 
 
 def test_generic_model_with_custom_name_no_warning(testdir):
@@ -21,7 +22,7 @@ def test_generic_model_with_custom_name_no_warning(testdir):
     """
     )
     result = testdir.runpytest("-Werror")  # Warnings become errors
-    result.assert_outcomes(passed=1)
+    assert_outcomes(result, passed=1)
 
 
 def test_generic_model_name_raises_warning(testdir):
@@ -44,7 +45,7 @@ def test_generic_model_name_raises_warning(testdir):
     """
     )
     result = testdir.runpytest()
-    result.assert_outcomes(passed=1)
+    assert_outcomes(result, passed=1)
     result.stdout.fnmatch_lines(
         "*UserWarning: Using a *class*dict* as model type for *JSONPayloadFactory* is discouraged*"
     )
@@ -70,7 +71,7 @@ def test_generic_model_with_register_override_no_warning(testdir):
         """
     )
     result = testdir.runpytest("-Werror")  # Warnings become errors
-    result.assert_outcomes(passed=1)
+    assert_outcomes(result, passed=1)
 
 
 def test_using_generic_model_name_for_subfactory_raises_warning(testdir):
@@ -103,7 +104,7 @@ def test_using_generic_model_name_for_subfactory_raises_warning(testdir):
     )
 
     result = testdir.runpytest()
-    result.assert_outcomes(errors=1)
+    assert_outcomes(result, errors=1)
     result.stdout.fnmatch_lines(
         "*UserWarning: Using *class*dict* as model type for *JSONPayloadFactory* is discouraged*"
     )

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -1,0 +1,109 @@
+# TODO: Unit test get_model_name
+
+
+def test_generic_model_with_custom_name_no_warning(testdir):
+    testdir.makepyfile(
+        """
+    from factory import Factory
+    from pytest_factoryboy import named_model, register
+
+    @register
+    class JSONPayloadFactory(Factory):
+        class Meta:
+            model = named_model(dict, "JSONPayload")
+        foo = "bar"
+
+
+    def test_payload(json_payload: dict):
+        assert isinstance(json_payload, dict)
+        assert json_payload["foo"] == "bar"
+
+    """
+    )
+    result = testdir.runpytest("-Werror")  # Warnings become errors
+    result.assert_outcomes(passed=1)
+
+
+def test_generic_model_name_raises_warning(testdir):
+    testdir.makepyfile(
+        """
+    import builtins
+    from factory import Factory
+    from pytest_factoryboy import register
+
+    @register
+    class JSONPayloadFactory(Factory):
+        class Meta:
+            model = dict
+        foo = "bar"
+
+
+    def test_payload(dict):
+        assert isinstance(dict, builtins.dict)
+        assert dict["foo"] == "bar"
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(
+        "*UserWarning: Using a *class*dict* as model type for *JSONPayloadFactory* is discouraged*"
+    )
+
+
+def test_generic_model_with_register_override_no_warning(testdir):
+    testdir.makepyfile(
+        """
+        from factory import Factory
+        from pytest_factoryboy import named_model, register
+
+        @register(_name="json_payload")
+        class JSONPayloadFactory(Factory):
+            class Meta:
+                model = dict
+            foo = "bar"
+
+
+        def test_payload(json_payload: dict):
+            assert isinstance(json_payload, dict)
+            assert json_payload["foo"] == "bar"
+
+        """
+    )
+    result = testdir.runpytest("-Werror")  # Warnings become errors
+    result.assert_outcomes(passed=1)
+
+
+def test_using_generic_model_name_for_subfactory_raises_warning(testdir):
+    testdir.makepyfile(
+        """
+        import builtins
+        from factory import Factory, SubFactory
+        from pytest_factoryboy import register
+
+        @register(_name="JSONPayload")
+        class JSONPayloadFactory(Factory):
+            class Meta:
+                model = dict  # no warning raised here, since we override the name at the @register(...)
+            foo = "bar"
+
+        class HTTPRequest:
+            def __init__(self, json: dict):
+                self.json = json
+
+        @register
+        class HTTPRequestFactory(Factory):
+            class Meta:
+                model = HTTPRequest
+
+            json = SubFactory(JSONPayloadFactory)  # this will raise a warning
+
+        def test_payload(http_request):
+            assert http_request.json["foo"] == "bar"
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(
+        "*UserWarning: Using *class*dict* as model type for *JSONPayloadFactory* is discouraged*"
+    )

--- a/tests/test_model_name.py
+++ b/tests/test_model_name.py
@@ -5,20 +5,19 @@ from tests.compat import assert_outcomes
 def test_generic_model_with_custom_name_no_warning(testdir):
     testdir.makepyfile(
         """
-    from factory import Factory
-    from pytest_factoryboy import named_model, register
+        from factory import Factory
+        from pytest_factoryboy import named_model, register
 
-    @register
-    class JSONPayloadFactory(Factory):
-        class Meta:
-            model = named_model(dict, "JSONPayload")
-        foo = "bar"
+        @register
+        class JSONPayloadFactory(Factory):
+            class Meta:
+                model = named_model(dict, "JSONPayload")
+            foo = "bar"
 
 
-    def test_payload(json_payload: dict):
-        assert isinstance(json_payload, dict)
-        assert json_payload["foo"] == "bar"
-
+        def test_payload(json_payload: dict):
+            assert isinstance(json_payload, dict)
+            assert json_payload["foo"] == "bar"
     """
     )
     result = testdir.runpytest("-Werror")  # Warnings become errors
@@ -28,20 +27,20 @@ def test_generic_model_with_custom_name_no_warning(testdir):
 def test_generic_model_name_raises_warning(testdir):
     testdir.makepyfile(
         """
-    import builtins
-    from factory import Factory
-    from pytest_factoryboy import register
+        import builtins
+        from factory import Factory
+        from pytest_factoryboy import register
 
-    @register
-    class JSONPayloadFactory(Factory):
-        class Meta:
-            model = dict
-        foo = "bar"
+        @register
+        class JSONPayloadFactory(Factory):
+            class Meta:
+                model = dict
+            foo = "bar"
 
 
-    def test_payload(dict):
-        assert isinstance(dict, builtins.dict)
-        assert dict["foo"] == "bar"
+        def test_payload(dict):
+            assert isinstance(dict, builtins.dict)
+            assert dict["foo"] == "bar"
     """
     )
     result = testdir.runpytest()


### PR DESCRIPTION
Implementing the idea previously described in https://github.com/pytest-dev/pytest-factoryboy/pull/163#issuecomment-1146873731.

We add a helper function, `named_model`, that makes sure the user uses a model with a specific name, rather than a generic dict, list, etc.

This way we avoid problems that arises when SubFactory and RelatedFactory are used with factories for generic models. See the tests for examples.