### PR TITLE
Slim stack traces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 - Using a generic class container like ``dict``, ``list``, ``set``, etc. will raise a warning suggesting you to wrap your model using ``named_model(...)``. Doing this will make sure that the fixture name is correctly chosen, otherwise SubFactory and RelatedFactory aren't able to determine the name of the model. See `Generic Container Classes as models <https://pytest-factoryboy.readthedocs.io/en/latest/#generic-container-classes-as-models>`_ `#167 <https://github.com/pytest-dev/pytest-factoryboy/pull/167>`_
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
+- Stack traces caused by pytest-factoryboy are now slimmer.
 
 2.4.0
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Unreleased
 ----------
 - Using a generic class container like ``dict``, ``list``, ``set``, etc. will raise a warning suggesting you to wrap your model using ``named_model(...)``. Doing this will make sure that the fixture name is correctly chosen, otherwise SubFactory and RelatedFactory aren't able to determine the name of the model. See `Generic Container Classes as models <https://pytest-factoryboy.readthedocs.io/en/latest/#generic-container-classes-as-models>`_ `#167 <https://github.com/pytest-dev/pytest-factoryboy/pull/167>`_
 - Fix ``Factory._after_postgeneration`` being invoked twice. `#164 <https://github.com/pytest-dev/pytest-factoryboy/pull/164>`_ `#156 <https://github.com/pytest-dev/pytest-factoryboy/issues/156>`_
-- Stack traces caused by pytest-factoryboy are now slimmer.
+- Stack traces caused by pytest-factoryboy are now slimmer. `#169 <https://github.com/pytest-dev/pytest-factoryboy/pull/169>`_
+- Check for naming conflicts between factory and model fixture name, and raise a clear error immediately. `#86 <https://github.com/pytest-dev/pytest-factoryboy/pull/86>`_
 
 2.4.0
 ----------

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 FactoryType: TypeAlias = Type[factory.Factory]
 F = TypeVar("F", bound=FactoryType)
 T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
 P = ParamSpec("P")
 
 SEPARATOR = "__"
@@ -58,16 +59,16 @@ class DeferredFunction:
         return self.function(request)
 
 
-class Box(Generic[T]):
+class Box(Generic[T_co]):
     """Simple box class, used to hold a value.
 
     The main purpose of this is to hold objects that we don't want to appear in stack traces.
     For example, the "caller_locals" dict holding a lot of items.
     """
 
-    value: T
+    value: T_co
 
-    def __init__(self, value: T):
+    def __init__(self, value: T_co):
         self.value = value
 
 


### PR DESCRIPTION
Having the `caller_locals` in the scope caused the stack traces to be very long.
Now we wrap `caller_locals` in a Box object, so that it's representation will be 1 line instead of 100.