### PR TITLE
Add support for factory fixtures to request other fixtures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,58 @@ Factory Fixture
             model = Author
 
 
-    register(AuthorFactory)  # => author_factory
+    register(AuthorFactory)  # => author_factory, author fixtures
+
+
+    def test_factory_fixture(author_factory):
+        author = author_factory(name="Charles Dickens")
+        assert author.name == "Charles Dickens"
+
+
+By default, ``register`` creates both a model fixture and a factory fixture.
+You can create a factory fixture only by passing the ``_factory_only=True``
+argument.
+
+.. code-block:: python
+
+    import factory
+    from pytest_factoryboy import register
+
+    class AuthorFactory(factory.Factory):
+        class Meta:
+            model = Author
+
+
+    register(AuthorFactory, _factory_only=True)  # => ONLY author_factory fixture
+
+
+    def test_factory_fixture(author_factory):
+        author = author_factory(name="Charles Dickens")
+        assert author.name == "Charles Dickens"
+
+This will throw an AssertionError if the factory fixture already exists, e.g.
+if ``register`` was already called with the same factory.
+
+When passing ``_factory_only=True`` to ``register``, you can also pass other
+fixtures that the factory fixture should request.
+
+.. code-block:: python
+
+    import factory
+    import pytest
+    from pytest_factoryboy import register
+
+    @pytest.fixture
+    def foo():
+        yield
+
+    class AuthorFactory(factory.Factory):
+        class Meta:
+            model = Author
+
+
+    # Creates author_factory fixture that requests foo fixture
+    register(AuthorFactory, _factory_only=True, _factory_request_fixtures=["foo"])
 
 
     def test_factory_fixture(author_factory):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -107,13 +107,13 @@ class TestRegisterWithAdditionalFixtures:
     register(OtherFooFactory, _name="without_bar")
 
     def test_register_factory(self, request, foo_factory):
-        assert 'bar' in request.fixturenames
+        assert "bar" in request.fixturenames
 
     def test_register_instance(self, request, with_bar):
-        assert 'bar' in request.fixturenames
+        assert "bar" in request.fixturenames
 
     def test_register_second_instance(self, request, without_bar):
-        assert 'bar' not in request.fixturenames
+        assert "bar" not in request.fixturenames
 
 
 class TestRegisterCall:

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -14,6 +14,11 @@ class Foo:
     value: str
 
 
+@pytest.fixture
+def bar(request):
+    pass
+
+
 class TestRegisterDirectDecorator:
     @register()
     class FooFactory(factory.Factory):
@@ -82,6 +87,33 @@ class TestRegisterAlternativeNameAndArgs:
         """Test that `register` can be invoked with `_name` to specify an alternative
         fixture name and with any kwargs to override the factory declarations."""
         assert second_foo.value == "second_bar"
+
+
+class TestRegisterWithAdditionalFixtures:
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = "register(FooFactory)"
+
+    class OtherFooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+        value = "register(OtherFooFactory)"
+
+    register(FooFactory, _factory_only=True, _factory_request_fixtures=["bar"])
+    register(FooFactory, _name="with_bar")
+    register(OtherFooFactory, _name="without_bar")
+
+    def test_register_factory(self, request, foo_factory):
+        assert 'bar' in request.fixturenames
+
+    def test_register_instance(self, request, with_bar):
+        assert 'bar' in request.fixturenames
+
+    def test_register_second_instance(self, request, without_bar):
+        assert 'bar' not in request.fixturenames
 
 
 class TestRegisterCall:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,3 +38,41 @@ def test_fixture_name_conflict():
 
     with pytest.raises(AssertionError, match="Naming collision"):
         register(FooFactory, "foo_factory")
+
+
+def test_factory_request_fixtures_without_factory_only():
+    class Foo:
+        pass
+
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+    with pytest.raises(AssertionError, match="Can't register factory request fixtures unless _factory_only=True."):
+        register(FooFactory, _factory_request_fixtures=["foo"])
+
+
+def test_name_with_factory_only():
+    class Foo:
+        pass
+
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+    with pytest.raises(AssertionError, match="Can't set _name when _factory_only=True."):
+        register(FooFactory, _name="foobar", _factory_only=True)
+
+
+def test_factory_only_after_model_fixture():
+    class Foo:
+        pass
+
+    class FooFactory(factory.Factory):
+        class Meta:
+            model = Foo
+
+    register(FooFactory)
+
+    with pytest.raises(AssertionError, match="Factory fixture foo_factory already exists."):
+        register(FooFactory, _factory_only=True)


### PR DESCRIPTION
Adds two arguments to register:

- `_factory_only` - determines whether only the factory fixture should be created
- `_factory_request_fixtures` - list of fixtures to be requested by the factory fixture. Only valid if `_factory_only` is set to True

This is one approach to solving https://github.com/pytest-dev/pytest-factoryboy/issues/201

---

**Example Usage:**

```python
class UserFactory(factory.django.DjangoModelFactory):
    class Meta:
        model = User

register(UserFactory, _factory_only=True, _factory_request_fixtures=['db'])
register(UserFactory, _name="test_user")

def test_user_name(test_user):
    assert test_user.first_name is not None
```

The first call `register` will create a factory fixture `user_factory` that requests the `db` fixture. The second call will create a model fixture `test_user` that requests the `user_factory` fixture (which requests the `db` fixture).

So the test `test_user_name` will request the `db` fixture as well. 



---


**Why not just add the `_factory_request_fixtures` kwarg? Why add `_factory_only` as well?**

Without the `_factory_only` flag, the first call to register a factory will implicitly create the factory fixture and will do so with whatever other args are passed, so in

```python
register(UserFactory, _name="test_user", _factory_request_fixtures=['db'])
register(UserFactory, _name="other_test_user")
```

`test_user` would request `user_factory` would request `db` AND `other_test_user` would request `user_factory` would request `db`

whereas in

```python
register(UserFactory, _name="other_test_user")
register(UserFactory, _name="test_user", _factory_request_fixtures=['db'])
```
`other_test_user` would request `user_factory` which would NOT request `db` AND `test_user` would request `user_factory` which would NOT request `db`

Looking at the second example here, it would be surprising to realize that the `test_user` and `user_factory` fixtures do not request `db`.

To make this more explicit, I added the `_factory_only` flag to encourage the user to explicitly construct the factory fixture with any requested fixtures they'd like before creating model fixtures.
