### PR TITLE
Adapt to `getfixturedefs` change in pytest 8.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+- Address compatibility issue with pytest 8.1. `#213 <https://github.com/pytest-dev/pytest-bdd/pull/213>`_
 
 2.6.0
 ----------

--- a/poetry.lock
+++ b/poetry.lock
@@ -536,4 +536,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7"
-content-hash = "cd68a5badaefeb63525aff0484fef3ce9e04938a1ac8ca2cc2a551a418841155"
+content-hash = "4c163068d378da2bfd22b01b77ca67733f74339568625cdd0f91de132202c975"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ inflection = "*"
 factory_boy = ">=2.10.0"
 pytest = ">=6.2"
 typing_extensions = "*"
+packaging = "*"
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.4.1"

--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -7,7 +7,6 @@ from importlib.metadata import version
 
 from _pytest.fixtures import FixtureDef, FixtureManager
 from _pytest.nodes import Node
-from packaging.version import Version
 from packaging.version import parse as parse_version
 
 pytest_version = parse_version(version("pytest"))
@@ -30,7 +29,7 @@ else:
         return path.with_name(stem + path.suffix)
 
 
-if pytest_version >= Version("8.1"):
+if pytest_version.release >= (8, 1):
 
     def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
         return fixturemanager.getfixturedefs(fixturename, node)

--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -12,7 +12,7 @@ from packaging.version import parse as parse_version
 
 pytest_version = parse_version(version("pytest"))
 
-__all__ = ("PostGenerationContext", "path_with_stem")
+__all__ = ("PostGenerationContext", "path_with_stem", "getfixturedefs")
 
 try:
     from factory.declarations import PostGenerationContext

--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 import pathlib
 import sys
+from collections.abc import Sequence
+from importlib.metadata import version
+
+from _pytest.fixtures import FixtureDef, FixtureManager
+from _pytest.nodes import Node
+from packaging.version import Version
+from packaging.version import parse as parse_version
+
+pytest_version = parse_version(version("pytest"))
 
 __all__ = ("PostGenerationContext", "path_with_stem")
 
@@ -19,3 +28,14 @@ else:
 
     def path_with_stem(path: pathlib.Path, stem: str) -> pathlib.Path:
         return path.with_name(stem + path.suffix)
+
+
+if pytest_version >= Version("8.1"):
+
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
+        return fixturemanager.getfixturedefs(fixturename, node)
+
+else:
+
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
+        return fixturemanager.getfixturedefs(fixturename, node.nodeid)

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from .compat import getfixturedefs
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -48,10 +50,7 @@ class Request:
         if fixture == "request":
             return deps
 
-        if hasattr(pytest, "version_tuple") and pytest.version_tuple >= (8, 1):
-            fixturedefs = request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent)
-        else:
-            fixturedefs = request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent.nodeid)
+        fixturedefs = getfixturedefs(request._fixturemanager, fixture, request._pyfuncitem.parent)
         for fixturedef in fixturedefs or []:
             for argname in fixturedef.argnames:
                 if argname not in deps:

--- a/pytest_factoryboy/plugin.py
+++ b/pytest_factoryboy/plugin.py
@@ -48,7 +48,11 @@ class Request:
         if fixture == "request":
             return deps
 
-        for fixturedef in request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent.nodeid) or []:
+        if hasattr(pytest, "version_tuple") and pytest.version_tuple >= (8, 1):
+            fixturedefs = request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent)
+        else:
+            fixturedefs = request._fixturemanager.getfixturedefs(fixture, request._pyfuncitem.parent.nodeid)
+        for fixturedef in fixturedefs or []:
             for argname in fixturedef.argnames:
                 if argname not in deps:
                     deps.add(argname)


### PR DESCRIPTION
The signature of this (private) function will change in the upcoming pytest 8.1 release:
https://github.com/pytest-dev/pytest/pull/11785

I verified that all tests pass when run against pytest main.