### PR TITLE
Fix example doc of named_model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ For example:
     @register
     class JSONPayload(factory.Factory):
         class Meta:
-            model = named_model("JSONPayload", dict)
+            model = named_model(dict, "JSONPayload")
 
         name = "foo"
 


### PR DESCRIPTION
fixed the usage example of named_model since it is incorrect comparing to the implementation. 

- doc: https://pytest-factoryboy.readthedocs.io/en/stable/index.html#generic-container-classes-as-models
- implementation: https://github.com/pytest-dev/pytest-factoryboy/blob/ca5bb0971e7fa393ad4e999560d2ca3da046c85e/pytest_factoryboy/fixture.py#L73C1-L75C40

