### PR TITLE
The parameter order of `named_model` in docs does not match the implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ For example:
     @register
     class JSONPayload(factory.Factory):
         class Meta:
-            model = named_model(dict, "JSONPayload")
+            model = named_model("JSONPayload", dict)
 
         name = "foo"
 


### PR DESCRIPTION
The parameters in the docs don't match the implementation where the `name` is the first argument.

```py
def named_model(model_cls: type[T], name: str) -> type[T]:
    """Return a model class with a given name."""
    return type(name, (model_cls,), {})
```