### PR TITLE
Fix pytest 8.4 compatibility

### DIFF
--- a/pytest_factoryboy/compat.py
+++ b/pytest_factoryboy/compat.py
@@ -6,10 +6,11 @@ from importlib.metadata import version
 from _pytest.fixtures import FixtureDef, FixtureManager
 from _pytest.nodes import Node
 from packaging.version import parse as parse_version
+from typing_extensions import TypeAlias
 
 pytest_version = parse_version(version("pytest"))
 
-__all__ = ("PostGenerationContext", "getfixturedefs")
+__all__ = ("PostGenerationContext", "getfixturedefs", "PytestFixtureT")
 
 try:
     from factory.declarations import PostGenerationContext
@@ -25,3 +26,13 @@ else:
 
     def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
         return fixturemanager.getfixturedefs(fixturename, node.nodeid)
+
+
+if pytest_version.release >= (8, 4):
+    from _pytest.fixtures import FixtureFunctionDefinition
+
+    PytestFixtureT: TypeAlias = FixtureFunctionDefinition
+else:
+    from _pytest.fixtures import FixtureFunction
+
+    PytestFixtureT: TypeAlias = FixtureFunction

--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -182,12 +182,12 @@ def create_fixture_with_related(
 ) -> Callable[P, T]:
     if related is None:
         related = []
-    f = create_fixture(name=name, function=function, fixtures=fixtures)
+    fixture, fn = create_fixture(name=name, function=function, fixtures=fixtures)
 
     # We have to set the `_factoryboy_related` attribute to the original function, since
     # FixtureDef.func will provide that one later when we discover the related fixtures.
-    f.__pytest_wrapped__.obj._factoryboy_related = related  # type: ignore[attr-defined]
-    return f
+    fn._factoryboy_related = related  # type: ignore[attr-defined]
+    return fixture
 
 
 def make_declaration_fixturedef(


### PR DESCRIPTION
Fix https://github.com/pytest-dev/pytest-factoryboy/issues/232

Checklist:
- [x] To be released only once pytest 8.4 is released and the fix is confirmed to work.