### PR TITLE
Fix fixture wrap with pytest 8.4

### DIFF
--- a/pytest_factoryboy/fixture.py
+++ b/pytest_factoryboy/fixture.py
@@ -186,7 +186,13 @@ def create_fixture_with_related(
 
     # We have to set the `_factoryboy_related` attribute to the original function, since
     # FixtureDef.func will provide that one later when we discover the related fixtures.
-    f.__pytest_wrapped__.obj._factoryboy_related = related  # type: ignore[attr-defined]
+    if hasattr(f, "__pytest_wrapped__"):
+        f.__pytest_wrapped__.obj._factoryboy_related = related
+    elif hasattr(f, "__wrapped__"):
+        f.__wrapped__._factoryboy_related = related
+    else:
+        raise AttributeError("Fixture object has no __pytest_wrapped__ nor __wrapped__ attribute")
+
     return f
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare = {homedir}/.tox/distshare
-envlist = py{3.9,3.10,3.11,3.12,3.13}-pytest{7.3,7.4,8.0,8.1,8.2,8.3,latest,main}
+envlist = py{3.9,3.10,3.11,3.12,3.13}-pytest{7.3,7.4,8.0,8.1,8.2,8.3,8.4,latest,main}
           py{3.9,3.10,3.11}-pytest{7.0,7.1,7.2}
           mypy
 
@@ -12,6 +12,7 @@ ignore_outcome =
 deps =
     pytestlatest: pytest
     pytestmain: git+https://github.com/pytest-dev/pytest.git@main
+    pytest8.4: pytest~=8.4.0
     pytest8.3: pytest~=8.3.0
     pytest8.2: pytest~=8.2.0
     pytest8.1: pytest~=8.1.0


### PR DESCRIPTION
`pytest-8.4.0` introduced a type for fixtures, removing the `__pytest_wrapped__` attribute on a fixture object.
Now instead of unwrapping the object, it now keeps `__wrapped__` that we can use instead.

This issue was breaking the CI on pytest latest (`v8.4.1`), so I took the opportunity to add `pytest-8.4.0` to `tox`.

See: https://github.com/pytest-dev/pytest/pull/12473